### PR TITLE
Add context to RunOnLoop

### DIFF
--- a/eventloop/eventloop_test.go
+++ b/eventloop/eventloop_test.go
@@ -1,9 +1,18 @@
 package eventloop
 
 import (
-	"github.com/dop251/goja"
+	"context"
 	"testing"
 	"time"
+
+	"github.com/dop251/goja"
+)
+
+type testContextKey string
+
+const (
+	someContextKey   testContextKey = "someContext"
+	someContextValue                = "someContextValue"
 )
 
 func TestRun(t *testing.T) {
@@ -46,6 +55,50 @@ func TestStart(t *testing.T) {
 
 	time.Sleep(2 * time.Second)
 	loop.Stop()
+}
+
+func TestStartWithContext(t *testing.T) {
+	const SCRIPT = `
+	setTimeout(function() {
+		console.log("ok");
+	}, 1000);
+	console.log("Started");
+	`
+
+	prg, err := goja.Compile("main.js", SCRIPT, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	loop := NewEventLoop()
+	loop.Start()
+
+	ctx := generateContext()
+	loop.RunOnLoopWithContext(ctx, func(vm *goja.Runtime) {
+		vm.RunProgram(prg)
+		verifyContext(t, loop)
+	})
+
+	time.Sleep(2 * time.Second)
+	loop.Stop()
+}
+
+func verifyContext(t *testing.T, eventLoop *EventLoop) {
+	ctx := eventLoop.GetContext()
+	if ctx == nil {
+		t.Error("expected EventLoop context but none was found")
+	}
+
+	result := ctx.Value(someContextKey)
+	if result != someContextValue {
+		t.Errorf("expected context %s to have value %s, but it was %v", someContextKey, someContextValue, result)
+	}
+}
+
+func generateContext() (ctx context.Context) {
+	ctx = context.Background()
+	ctx = context.WithValue(ctx, someContextKey, someContextValue)
+	return
 }
 
 func TestInterval(t *testing.T) {


### PR DESCRIPTION
Hi Dmitry!

Im a huge goja fan! I found your project over 2 years ago and it has opened up new worlds of development to me. Many thanks for the awesome engine!

I use olebedev's gojax for fetching, and have a small change I want to get your opinion (and hopefully approval) on adding a context to the event loop so user defined, loop execution specific data can be accessed by extensions like gojax's fetch.

The driving factor behind this change was that gojax makes a "synthetic" request for the fetch, which works very well for about 90% or so of use cases. The other 10% of my use cases involve auth of some kind (either header value based, cookie based for more serious auth, or I have a handler attach context earlier in the handler/middleware chain to the request (a simple example would be a situation where I do some auth validation to cache some access controls or other request specific metadata to a request to prevent multiple calls for the same data in a call chain).

I have built and tested the change (with gojax updates) in my testbed app and verified context scope when under load.

I will put up the PR for the companion gojax change next, and will add a link to it below.

So, what do you think?

P.S: Thanks again for goja! You rock!