### PR TITLE
eventloop: Allow creating loop without loading "console" module

### DIFF
--- a/eventloop/eventloop_test.go
+++ b/eventloop/eventloop_test.go
@@ -1,9 +1,10 @@
 package eventloop
 
 import (
-	"github.com/dop251/goja"
 	"testing"
 	"time"
+
+	"github.com/dop251/goja"
 )
 
 func TestRun(t *testing.T) {
@@ -80,5 +81,53 @@ func TestRunNoSchedule(t *testing.T) {
 
 	if !fired {
 		t.Fatal("Not fired")
+	}
+}
+
+func TestRunWithConsole(t *testing.T) {
+	const SCRIPT = `
+	console.log("Started");
+	`
+
+	loop := NewEventLoop()
+	prg, err := goja.Compile("main.js", SCRIPT, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	loop.Run(func(vm *goja.Runtime) {
+		_, err = vm.RunProgram(prg)
+	})
+	if err != nil {
+		t.Fatal("Call to console.log generated an error", err)
+	}
+
+	loop = NewEventLoop(EnableConsole(true))
+	prg, err = goja.Compile("main.js", SCRIPT, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	loop.Run(func(vm *goja.Runtime) {
+		_, err = vm.RunProgram(prg)
+	})
+	if err != nil {
+		t.Fatal("Call to console.log generated an error", err)
+	}
+}
+
+func TestRunNoConsole(t *testing.T) {
+	const SCRIPT = `
+	console.log("Started");
+	`
+
+	loop := NewEventLoop(EnableConsole(false))
+	prg, err := goja.Compile("main.js", SCRIPT, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	loop.Run(func(vm *goja.Runtime) {
+		_, err = vm.RunProgram(prg)
+	})
+	if err == nil {
+		t.Fatal("Call to console.log did not generate an error", err)
 	}
 }


### PR DESCRIPTION
Remove the call to console.Enable in eventloop.NewEventLoop, thus
making it possible to create an event loop without automatically
loading the `console` commands into the runtime.  The eventloop tests
which make calls to `console.log` have been updated to call
console.Enable within loop.Run just before evaluating the test's
JavaScript string.