### PR TITLE
console: Allow configuring custom output for console

### DIFF
--- a/console/module.go
+++ b/console/module.go
@@ -11,35 +11,64 @@ import (
 type Console struct {
 	runtime *goja.Runtime
 	util    *goja.Object
+	printer Printer
 }
 
-func (c *Console) log(call goja.FunctionCall) goja.Value {
-	if format, ok := goja.AssertFunction(c.util.Get("format")); ok {
-		ret, err := format(c.util, call.Arguments...)
-		if err != nil {
-			panic(err)
+type Printer interface {
+	Log(string)
+	Warn(string)
+	Error(string)
+}
+
+type PrinterFunc func(s string)
+
+func (p PrinterFunc) Log(s string) { p(s) }
+
+func (p PrinterFunc) Warn(s string) { p(s) }
+
+func (p PrinterFunc) Error(s string) { p(s) }
+
+var defaultPrinter Printer = PrinterFunc(func(s string) { log.Print(s) })
+
+func (c *Console) log(p func(string)) func(goja.FunctionCall) goja.Value {
+	return func(call goja.FunctionCall) goja.Value {
+		if format, ok := goja.AssertFunction(c.util.Get("format")); ok {
+			ret, err := format(c.util, call.Arguments...)
+			if err != nil {
+				panic(err)
+			}
+
+			p(ret.String())
+		} else {
+			panic(c.runtime.NewTypeError("util.format is not a function"))
 		}
 
-		log.Print(ret.String())
-	} else {
-		panic(c.runtime.NewTypeError("util.format is not a function"))
+		return nil
 	}
-
-	return nil
 }
 
 func Require(runtime *goja.Runtime, module *goja.Object) {
-	c := &Console{
-		runtime: runtime,
+	requireWithPrinter(defaultPrinter)(runtime, module)
+}
+
+func RequireWithPrinter(printer Printer) require.ModuleLoader {
+	return requireWithPrinter(printer)
+}
+
+func requireWithPrinter(printer Printer) require.ModuleLoader {
+	return func(runtime *goja.Runtime, module *goja.Object) {
+		c := &Console{
+			runtime: runtime,
+			printer: printer,
+		}
+
+		c.util = require.Require(runtime, "util").(*goja.Object)
+
+		o := module.Get("exports").(*goja.Object)
+		o.Set("log", c.log(c.printer.Log))
+		o.Set("error", c.log(c.printer.Error))
+		o.Set("warn", c.log(c.printer.Warn))
 	}
-
-	c.util = require.Require(runtime, "util").(*goja.Object)
-
-	o := module.Get("exports").(*goja.Object)
-	o.Set("log", c.log)
-	o.Set("error", c.log)
-	o.Set("warn", c.log)
-
 }
 
 func Enable(runtime *goja.Runtime) {

--- a/console/module_test.go
+++ b/console/module_test.go
@@ -29,3 +29,42 @@ func TestConsole(t *testing.T) {
 		t.Fatal("console.warn() error", err)
 	}
 }
+
+func TestConsoleWithPrinter(t *testing.T) {
+	vm := goja.New()
+
+	var lastPrint string
+	printer := PrinterFunc(func(s string) {
+		lastPrint = s
+	})
+
+	registry := new(require.Registry)
+	registry.Enable(vm)
+	registry.RegisterNativeModule("console", RequireWithPrinter(printer))
+	Enable(vm)
+
+	if c := vm.Get("console"); c == nil {
+		t.Fatal("console not found")
+	}
+
+	if _, err := vm.RunString("console.log('log')"); err != nil {
+		t.Fatal("console.log() error", err)
+	}
+	if lastPrint != "log" {
+		t.Fatal("lastPrint not 'log'", lastPrint)
+	}
+
+	if _, err := vm.RunString("console.error('error')"); err != nil {
+		t.Fatal("console.error() error", err)
+	}
+	if lastPrint != "error" {
+		t.Fatal("lastPrint not 'error'", lastPrint)
+	}
+
+	if _, err := vm.RunString("console.warn('warn')"); err != nil {
+		t.Fatal("console.warn() error", err)
+	}
+	if lastPrint != "warn" {
+		t.Fatal("lastPrint not 'warn'", lastPrint)
+	}
+}


### PR DESCRIPTION
Allow configuring where `console` commands print to with the addition
of a new RequireWithPrinter(Printer) function which returns a
require.ModuleLoader that loads a `console` command into the given
runtime which writes to the supplied Printer.

Printer is a new interface type with a single method, Print(string).
A new private `printer` field has been added to the Console type, and
(c *Console).log now calls `c.printer.Print` to print the final string
after formatting its arguments.  A helper type PrinterFunc can be used
to create a Printer from a function with signature `func(string)`.

If a custom Printer is not given, a default Printer is used which
passes its string argument unmodified to log.Print, thus preserving
the existing behavior.

Added a new test TestConsoleWithPrinter which ensures that the
`console` command functions correctly when loaded into a runtime using
RequireWithPrinter and a custom Printer.