### PR TITLE
require: Add partial implementation of module search algorithm

### DIFF
--- a/require/module_test.go
+++ b/require/module_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"path/filepath"
 	"testing"
 
 	js "github.com/dop251/goja"
@@ -128,12 +129,12 @@ func TestSourceLoader(t *testing.T) {
 
 	vm := js.New()
 
-	registry := NewRegistryWithLoader(func(name string) ([]byte, error) {
+	registry := NewRegistry(WithGlobalFolders("."), WithLoader(func(name string) ([]byte, error) {
 		if name == "m.js" {
 			return []byte(MODULE), nil
 		}
 		return nil, errors.New("Module does not exist")
-	})
+	}))
 	registry.Enable(vm)
 
 	v, err := vm.RunString(SCRIPT)
@@ -166,12 +167,12 @@ func TestStrictModule(t *testing.T) {
 
 	vm := js.New()
 
-	registry := NewRegistryWithLoader(func(name string) ([]byte, error) {
+	registry := NewRegistry(WithGlobalFolders("."), WithLoader(func(name string) ([]byte, error) {
 		if name == "m.js" {
 			return []byte(MODULE), nil
 		}
 		return nil, errors.New("Module does not exist")
-	})
+	}))
 	registry.Enable(vm)
 
 	v, err := vm.RunString(SCRIPT)
@@ -181,5 +182,107 @@ func TestStrictModule(t *testing.T) {
 
 	if !v.StrictEquals(vm.ToValue("passed1")) {
 		t.Fatalf("Unexpected result: %v", v)
+	}
+}
+
+func TestResolve(t *testing.T) {
+	mapFileSystemSourceLoader := func(files map[string]string) SourceLoader {
+		return func(path string) ([]byte, error) {
+			slashPath := filepath.ToSlash(path)
+			t.Logf("SourceLoader(%s) [%s]", path, slashPath)
+			s, ok := files[filepath.ToSlash(slashPath)]
+			if !ok {
+				return nil, InvalidModuleError
+			}
+			return []byte(s), nil
+		}
+	}
+
+	testRequire := func(src, path string, globalFolders []string, fs map[string]string) (*js.Runtime, js.Value, error) {
+		vm := js.New()
+		r := NewRegistry(WithGlobalFolders(globalFolders...), WithLoader(mapFileSystemSourceLoader(fs)))
+		rr := r.Enable(vm)
+		rr.resolveStart = src
+		t.Logf("Require(%s)", path)
+		ret, err := rr.Require(path)
+		if err != nil {
+			return nil, nil, err
+		}
+		return vm, ret, nil
+	}
+
+	globalFolders := []string{
+		"/usr/lib/node_modules",
+		"/home/src/.node_modules",
+	}
+
+	fs := map[string]string{
+		"/home/src/app/app.js":                   `exports.name = "app"`,
+		"/home/src/app2/app2.json":               `{"name": "app2"}`,
+		"/home/src/app3/index.js":                `exports.name = "app3"`,
+		"/home/src/app4/index.json":              `{"name": "app4"}`,
+		"/home/src/app5/package.json":            `{"main": "app5.js"}`,
+		"/home/src/app5/app5.js":                 `exports.name = "app5"`,
+		"/home/src/app6/package.json":            `{"main": "."}`,
+		"/home/src/app6/index.js":                `exports.name = "app6"`,
+		"/home/src/app7/package.json":            `{"main": "./a/b/c/file.js"}`,
+		"/home/src/app7/a/b/c/file.js":           `exports.name = "app7"`,
+		"/usr/lib/node_modules/app8":             `exports.name = "app8"`,
+		"/home/src/app9/app9.js":                 `exports.name = require('./a/file.js').name`,
+		"/home/src/app9/a/file.js":               `exports.name = require('./b/file.js').name`,
+		"/home/src/app9/a/b/file.js":             `exports.name = require('./c/file.js').name`,
+		"/home/src/app9/a/b/c/file.js":           `exports.name = "app9"`,
+		"/home/src/.node_modules/app10":          `exports.name = "app10"`,
+		"/home/src/app11/a/b/c/app11.js":         `exports.name = require('d/file.js').name`,
+		"/home/src/app11/node_modules/d/file.js": `exports.name = "app11"`,
+		"/app12.js":                              `exports.name = require('a/file.js').name`,
+		"/node_modules/a/file.js":                `exports.name = "app12"`,
+		"/app13/app13.js":                        `exports.name = require('b/file.js').name`,
+		"/node_modules/b/file.js":                `exports.name = "app13"`,
+	}
+
+	for i, tc := range []struct {
+		src   string
+		path  string
+		ok    bool
+		field string
+		value string
+	}{
+		{"/home/src", "./app/app", true, "name", "app"},
+		{"/home/src", "./app/app.js", true, "name", "app"},
+		{"/home/src", "./app/bad.js", false, "", ""},
+		{"/home/src", "./app2/app2", true, "name", "app2"},
+		{"/home/src", "./app2/app2.json", true, "name", "app2"},
+		{"/home/src", "./app/bad.json", false, "", ""},
+		{"/home/src", "./app3", true, "name", "app3"},
+		{"/home/src", "./appbad", false, "", ""},
+		{"/home/src", "./app4", true, "name", "app4"},
+		{"/home/src", "./appbad", false, "", ""},
+		{"/home/src", "./app5", true, "name", "app5"},
+		{"/home/src", "./app6", true, "name", "app6"},
+		{"/home/src", "./app7", true, "name", "app7"},
+		{"/home/src", "app8", true, "name", "app8"},
+		{"/home/src", "./app9/app9", true, "name", "app9"},
+		{"/home/src", "app10", true, "name", "app10"},
+		{"/home/src", "./app11/a/b/c/app11.js", true, "name", "app11"},
+		{"/", "./app12", true, "name", "app12"},
+		{"/", "./app13/app13", true, "name", "app13"},
+	} {
+		vm, mod, err := testRequire(tc.src, tc.path, globalFolders, fs)
+		if err != nil {
+			if tc.ok {
+				t.Errorf("%v: require() failed: %v", i, err)
+			}
+			continue
+		}
+		f := mod.ToObject(vm).Get(tc.field)
+		if f == nil {
+			t.Errorf("%v: field %q not found", i, tc.field)
+			continue
+		}
+		value := f.String()
+		if value != tc.value {
+			t.Errorf("%v: got %q expected %q", i, value, tc.value)
+		}
 	}
 }

--- a/require/resolve.go
+++ b/require/resolve.go
@@ -1,0 +1,156 @@
+package require
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"strings"
+)
+
+// NodeJS module search algorithm described by
+// https://nodejs.org/api/modules.html#modules_all_together
+func (r *RequireModule) resolve(path string) (resolvedPath string, err error) {
+	origPath, path := path, filepathClean(path)
+	if path == "" {
+		return "", IllegalModuleNameError
+	}
+
+	resolvedPath, err = r.loadNative(path)
+	if err == nil {
+		return resolvedPath, nil
+	}
+
+	start := r.resolveStart
+	if strings.HasPrefix(origPath, "/") {
+		start = "/"
+	}
+
+	if strings.HasPrefix(origPath, "./") ||
+		strings.HasPrefix(origPath, "/") || strings.HasPrefix(origPath, "../") ||
+		origPath == "." || origPath == ".." {
+		p := filepath.Join(start, path)
+		resolvedPath, err = r.loadAsFileOrDirectory(p)
+		if err == nil {
+			return resolvedPath, nil
+		}
+		return "", InvalidModuleError
+	}
+
+	p := filepath.Dir(start)
+	resolvedPath, err = r.loadNodeModules(path, p)
+	if err == nil {
+		return resolvedPath, nil
+	}
+
+	return "", InvalidModuleError
+}
+
+func (r *RequireModule) loadNative(path string) (string, error) {
+	path = filepathClean(path)
+	if _, exists := r.r.native[path]; exists {
+		return path, nil
+	}
+	if _, exists := native[path]; exists {
+		return path, nil
+	}
+	return "", InvalidModuleError
+}
+
+func (r *RequireModule) loadAsFileOrDirectory(path string) (string, error) {
+	path = filepathClean(path)
+	resolvedPath, err := r.loadAsFile(path)
+	if err == nil {
+		return resolvedPath, nil
+	}
+	resolvedPath, err = r.loadAsDirectory(path)
+	if err == nil {
+		return resolvedPath, nil
+	}
+	return "", InvalidModuleError
+}
+
+func (r *RequireModule) loadAsFile(path string) (string, error) {
+	path = filepathClean(path)
+	_, err := r.r.getSource(path)
+	if err == nil {
+		return path, nil
+	}
+	p := path + ".js"
+	_, err = r.r.getSource(p)
+	if err == nil {
+		return p, nil
+	}
+	p = path + ".json"
+	_, err = r.r.getSource(p)
+	if err == nil {
+		return p, nil
+	}
+	return "", InvalidModuleError
+}
+
+func (r *RequireModule) loadIndex(path string) (string, error) {
+	path = filepathClean(path)
+	p := filepath.Join(path, "index.js")
+	_, err := r.r.getSource(p)
+	if err == nil {
+		return p, nil
+	}
+	p = filepath.Join(path, "index.json")
+	_, err = r.r.getSource(p)
+	if err == nil {
+		return p, nil
+	}
+	return "", InvalidModuleError
+}
+
+func (r *RequireModule) loadAsDirectory(path string) (string, error) {
+	path = filepathClean(path)
+	p := filepath.Join(path, "package.json")
+	buf, err := r.r.getSource(p)
+	if err != nil {
+		return r.loadIndex(path)
+	}
+	var pkg struct {
+		Main string
+	}
+	err = json.Unmarshal(buf, &pkg)
+	if err != nil || len(pkg.Main) == 0 {
+		return r.loadIndex(path)
+	}
+	m := filepath.Join(path, pkg.Main)
+	resolvedPath, err := r.loadAsFile(m)
+	if err == nil {
+		return resolvedPath, nil
+	}
+	resolvedPath, err = r.loadIndex(m)
+	if err == nil {
+		return resolvedPath, nil
+	}
+	return "", InvalidModuleError
+}
+
+func (r *RequireModule) loadNodeModules(path, start string) (string, error) {
+	dirs, err := r.nodeModulesPaths(start)
+	if err != nil {
+		return "", err
+	}
+	for _, dir := range dirs {
+		p := filepath.Join(dir, path)
+		resolvedPath, err := r.loadAsFileOrDirectory(p)
+		if err == nil {
+			return resolvedPath, nil
+		}
+	}
+	return "", InvalidModuleError
+}
+
+func (r *RequireModule) nodeModulesPaths(start string) ([]string, error) {
+	dirs := r.r.globalFolders
+	prev, dir := "", filepath.Dir(start)
+	for prev != dir {
+		if filepath.Base(dir) != "node_modules" {
+			dirs = append(dirs, filepath.Join(dir, "node_modules"))
+		}
+		prev, dir = dir, filepath.Dir(dir)
+	}
+	return dirs, nil
+}


### PR DESCRIPTION
Add a partial implementation of the Node.js module search algorithm
described here:

https://nodejs.org/api/modules.html#modules_all_together

The functions LOAD_AS_FILE, LOAD_INDEX, LOAD_AS_DIRECTORY,
LOAD_NODE_MODULES and NODE_MODULES_PATHS outlined in the pseudocode
linked above are implemented, whereas the functionality outlined in
LOAD_SELF_REFERENCE and LOAD_PACKAGE_EXPORTS is missing.

The module resolution algorithm is implemented via a
new (*RequireModule).resolve(path string) method which returns the
resolved path to a file that can be loaded using the Registry's
SourceLoader.  The returned resolved path is always cleaned via
filepathClean.  The resolve method uses the Registry's SourceLoader
via the new (*Registry).getSource(path string) method to search for
modules and supports resolving both native ("core") and JavaScript
modules.

Add new resolveStart string field to RequireModule.  resolveStart is
used to store the initial start path for the module search algorithm in the
resolve method.  When require() is called from the global context,
resolveStart should be set to the directory of the currently executing
script.  This information is stored in r.runtime.Program.src.name but
is not currently exported, therefore for now resolveStart is set to
".".  During a nested require() call, resolveStart is set to the
directory of the module currently being loaded.

Add new constructor NewRegistry which takes a variadic argument of
Option's.  Currently, valid options are WithLoader and
WithGlobalFolders.

Add new globalFolders string slice to Registry.  globalFolders stores
additional folders that are searched by require() and is used in
NODE_MODULES_PATHS in the pseudocode linked above.  By default, a
Registry has an empty globalFolders slice, but this can be changed
using WithGlobalFolders.

Add support for loading modules with a .json extension by passing the
contents of the file through JavaScript's JSON.parse and assigning the
return value to module.exports within the module wrapper function.

Add new test TestResolve to test module search algorithm.

Fixes #5.