### PR TITLE
Add nil checks for clearTimeout and clearInterval.

### DIFF
--- a/eventloop/eventloop.go
+++ b/eventloop/eventloop.go
@@ -288,7 +288,7 @@ func (loop *EventLoop) doInterval(i *Interval) {
 }
 
 func (loop *EventLoop) clearTimeout(t *Timer) {
-	if !t.cancelled {
+	if t != nil && !t.cancelled {
 		t.timer.Stop()
 		t.cancelled = true
 		loop.jobCount--
@@ -296,7 +296,7 @@ func (loop *EventLoop) clearTimeout(t *Timer) {
 }
 
 func (loop *EventLoop) clearInterval(i *Interval) {
-	if !i.cancelled {
+	if i != nil && !i.cancelled {
 		i.cancelled = true
 		close(i.stopChan)
 		loop.jobCount--


### PR DESCRIPTION
Hi!

This adds nil checks to the arguments passed to `clearTimeout`/`clearInterval` for the use case of running buggy/untrusted JS code. I thought it would be better to do the check here - and not in the exported `ClearTimeout`/`ClearInterval` - because it's clearer what can break.