### PR TITLE
Update setInterval and setTimeout to follow node behavior when timeout is not provided

### DIFF
--- a/eventloop/eventloop.go
+++ b/eventloop/eventloop.go
@@ -250,6 +250,11 @@ func (loop *EventLoop) addAuxJob(fn func()) {
 }
 
 func (loop *EventLoop) addTimeout(f func(), timeout time.Duration) *Timer {
+	// If no timeout is provided set timeout to 1ms.  Follows node documentation.
+	// https://nodejs.org/api/timers.html#timers_settimeout_callback_delay_args
+	if timeout <= 0 {
+		timeout = time.Millisecond
+	}
 	t := &Timer{
 		job: job{fn: f},
 	}
@@ -263,6 +268,12 @@ func (loop *EventLoop) addTimeout(f func(), timeout time.Duration) *Timer {
 }
 
 func (loop *EventLoop) addInterval(f func(), timeout time.Duration) *Interval {
+	// If no timeout is provided set timeout to 1ms. Follows node documentation.
+	// https://nodejs.org/api/timers.html#timers_setinterval_callback_delay_args
+	if timeout <= 0 {
+		timeout = time.Millisecond
+	}
+
 	i := &Interval{
 		job:      job{fn: f},
 		ticker:   time.NewTicker(timeout),

--- a/eventloop/eventloop.go
+++ b/eventloop/eventloop.go
@@ -250,11 +250,6 @@ func (loop *EventLoop) addAuxJob(fn func()) {
 }
 
 func (loop *EventLoop) addTimeout(f func(), timeout time.Duration) *Timer {
-	// If no timeout is provided set timeout to 1ms.  Follows node documentation.
-	// https://nodejs.org/api/timers.html#timers_settimeout_callback_delay_args
-	if timeout <= 0 {
-		timeout = time.Millisecond
-	}
 	t := &Timer{
 		job: job{fn: f},
 	}
@@ -268,7 +263,6 @@ func (loop *EventLoop) addTimeout(f func(), timeout time.Duration) *Timer {
 }
 
 func (loop *EventLoop) addInterval(f func(), timeout time.Duration) *Interval {
-	// If no timeout is provided set timeout to 1ms. Follows node documentation.
 	// https://nodejs.org/api/timers.html#timers_setinterval_callback_delay_args
 	if timeout <= 0 {
 		timeout = time.Millisecond


### PR DESCRIPTION
When `setInterval` is called without supplying a timeout parameter it causes a panic to occur.
This is because `addInterval` is using `time.NewTicker` and documentation specifies:

> The duration d must be greater than zero; if not, NewTicker will panic.
https://pkg.go.dev/time#NewTicker

To remain in align with node behavior, if a timeout is not provided it should be defaulted to 1ms.
https://nodejs.org/api/timers.html#timers_setinterval_callback_delay_args

The same is true if a timeout is not provided to `setTimeout`
https://nodejs.org/api/timers.html#timers_settimeout_callback_delay_args
