### PR TITLE
Registry new option "WithHotReload"

### DIFF
--- a/require/resolve.go
+++ b/require/resolve.go
@@ -17,6 +17,11 @@ func (r *RequireModule) resolve(modpath string) (module *js.Object, err error) {
 		return nil, IllegalModuleNameError
 	}
 
+	if r.hotReload {
+		r.modules = map[string]*js.Object{}
+		r.nodeModules = map[string]*js.Object{}
+	}
+
 	module, err = r.loadNative(modpath)
 	if err == nil {
 		return


### PR DESCRIPTION
This new option causes `require` to always reload code from source.
`require.NewRegistry(require.WithHotReload())`

I implemented this because we need this. It is fine if the project does not want this code then we just fork.

Performance for the regular registry stays the same (the only overhead are 2 if statements). When hot reload is enabled the performance obviously drops.

Hot reload can only be enabled per registry and not be disabled since we don't need this and it would just make the code more complex.