### PR TITLE
Minimal implementation to provide `process.env`

### DIFF
--- a/process/module.go
+++ b/process/module.go
@@ -1,0 +1,35 @@
+package process
+
+import (
+	"os"
+	"strings"
+
+	"github.com/dop251/goja"
+	"github.com/dop251/goja_nodejs/require"
+)
+
+type Process struct {
+	env map[string]string
+}
+
+func Require(runtime *goja.Runtime, module *goja.Object) {
+	p := &Process{
+		env: make(map[string]string),
+	}
+
+	for _, e := range os.Environ() {
+		envKeyValue := strings.SplitN(e, "=", 2)
+		p.env[envKeyValue[0]] = envKeyValue[1]
+	}
+
+	o := module.Get("exports").(*goja.Object)
+	o.Set("env", p.env)
+}
+
+func Enable(runtime *goja.Runtime) {
+	runtime.Set("process", require.Require(runtime, "process"))
+}
+
+func init() {
+	require.RegisterNativeModule("process", Require)
+}

--- a/process/module_test.go
+++ b/process/module_test.go
@@ -1,0 +1,68 @@
+package process
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/dop251/goja"
+	"github.com/dop251/goja_nodejs/require"
+)
+
+func TestProcessEnvStructure(t *testing.T) {
+	vm := goja.New()
+
+	new(require.Registry).Enable(vm)
+	Enable(vm)
+
+	if c := vm.Get("process"); c == nil {
+		t.Fatal("process not found")
+	}
+
+	if c, err := vm.RunString("process.env"); c == nil || err != nil {
+		t.Fatal("error accessing process.env")
+	}
+}
+
+func TestProcessEnvValuesArtificial(t *testing.T) {
+	os.Setenv("GOJA_IS_AWESOME", "true")
+	defer os.Unsetenv("GOJA_IS_AWESOME")
+
+	vm := goja.New()
+
+	new(require.Registry).Enable(vm)
+	Enable(vm)
+
+	jsRes, err := vm.RunString("process.env['GOJA_IS_AWESOME']")
+
+	if err != nil {
+		t.Fatal(fmt.Sprintf("Error executing: %s", err))
+	}
+
+	if jsRes.String() != "true" {
+		t.Fatal(fmt.Sprintf("Error executing: got %s but expected %s", jsRes, "true"))
+	}
+}
+
+func TestProcessEnvValuesBrackets(t *testing.T) {
+	vm := goja.New()
+
+	new(require.Registry).Enable(vm)
+	Enable(vm)
+
+	for _, e := range os.Environ() {
+		envKeyValue := strings.SplitN(e, "=", 2)
+		jsExpr := fmt.Sprintf("process.env['%s']", envKeyValue[0])
+
+		jsRes, err := vm.RunString(jsExpr)
+
+		if err != nil {
+			t.Fatal(fmt.Sprintf("Error executing %s: %s", jsExpr, err))
+		}
+
+		if jsRes.String() != envKeyValue[1] {
+			t.Fatal(fmt.Sprintf("Error executing %s: got %s but expected %s", jsExpr, jsRes, envKeyValue[1]))
+		}
+	}
+}


### PR DESCRIPTION
As discussed in #32: This is a very minimal "implementation" of `process.env` to provide data for exactly this use case. I fear this will be incompatible if anyone attempts to build a "real" implementation of the node.js `process` API, so I deliberately named the plugin `process.env`.