### PR TITLE
Fix deadlock on calling `EventLoop.Stop`

### DIFF
--- a/eventloop/eventloop.go
+++ b/eventloop/eventloop.go
@@ -82,6 +82,13 @@ func NewEventLoop(opts ...Option) *EventLoop {
 
 type Option func(*EventLoop)
 
+// WithRuntime set the goja.Runtime insteat of create a new one
+func WithRuntime(runtime *goja.Runtime) Option {
+	return func(loop *EventLoop) {
+		loop.vm = runtime
+	}
+}
+
 // EnableConsole controls whether the "console" module is loaded into
 // the runtime used by the loop.  By default, loops are created with
 // the "console" module loaded, pass EnableConsole(false) to
@@ -96,6 +103,11 @@ func WithRegistry(registry *require.Registry) Option {
 	return func(loop *EventLoop) {
 		loop.registry = registry
 	}
+}
+
+// Runtime returns the goja.Runtime used by the loop
+func (loop *EventLoop) Runtime() *goja.Runtime {
+	return loop.vm
 }
 
 func (loop *EventLoop) schedule(call goja.FunctionCall, repeating bool) goja.Value {

--- a/eventloop/eventloop.go
+++ b/eventloop/eventloop.go
@@ -194,15 +194,19 @@ func (loop *EventLoop) Start() {
 // It is not allowed to run Start() and Stop() concurrently.
 // Calling Stop() on an already stopped loop or inside the loop will hang.
 func (loop *EventLoop) Stop() {
+	loop.stopCond.L.Lock()
+	defer loop.stopCond.L.Unlock()
+	if !loop.running {
+		return
+	}
+
 	loop.jobChan <- func() {
 		loop.canRun = false
 	}
 
-	loop.stopCond.L.Lock()
 	for loop.running {
 		loop.stopCond.Wait()
 	}
-	loop.stopCond.L.Unlock()
 }
 
 // RunOnLoop schedules to run the specified function in the context of the loop as soon as possible.

--- a/eventloop/eventloop_test.go
+++ b/eventloop/eventloop_test.go
@@ -9,8 +9,12 @@ import (
 	"github.com/dop251/goja"
 )
 
+const parallelTest = true
+
 func TestRun(t *testing.T) {
-	t.Parallel()
+	if parallelTest {
+		t.Parallel()
+	}
 	const SCRIPT = `
 	setTimeout(function() {
 		console.log("ok");
@@ -29,7 +33,9 @@ func TestRun(t *testing.T) {
 }
 
 func TestStart(t *testing.T) {
-	t.Parallel()
+	if parallelTest {
+		t.Parallel()
+	}
 	const SCRIPT = `
 	setTimeout(function() {
 		console.log("ok");
@@ -53,8 +59,54 @@ func TestStart(t *testing.T) {
 	loop.Stop()
 }
 
+func TestStop(t *testing.T) {
+	if parallelTest {
+		t.Parallel()
+	}
+	const SCRIPT = `
+	setTimeout(function() {
+		console.log("not ok");
+		throw 'failed';
+	}, 1000);
+	console.log("Started");
+	`
+
+	prg, err := goja.Compile("main.js", SCRIPT, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	loop := NewEventLoop()
+	loop.Start()
+
+	loop.RunOnLoop(func(vm *goja.Runtime) {
+		vm.RunProgram(prg)
+	})
+
+	time.Sleep(500 * time.Millisecond)
+	loop.Stop()
+	time.Sleep(time.Second)
+	loop.Stop()
+}
+
+func TestStop2(t *testing.T) {
+	if parallelTest {
+		t.Parallel()
+	}
+
+	loop := NewEventLoop()
+	loop.Start()
+
+	go loop.Stop()
+	go loop.Stop()
+	loop.Stop()
+	time.Sleep(500 * time.Millisecond)
+}
+
 func TestInterval(t *testing.T) {
-	t.Parallel()
+	if parallelTest {
+		t.Parallel()
+	}
 	const SCRIPT = `
 	var count = 0;
 	var t = setInterval(function() {
@@ -138,7 +190,9 @@ func TestRunNoConsole(t *testing.T) {
 }
 
 func TestClearIntervalRace(t *testing.T) {
-	t.Parallel()
+	if parallelTest {
+		t.Parallel()
+	}
 	const SCRIPT = `
 	console.log("calling setInterval");
 	var t = setInterval(function() {
@@ -165,7 +219,9 @@ func TestClearIntervalRace(t *testing.T) {
 }
 
 func TestNativeTimeout(t *testing.T) {
-	t.Parallel()
+	if parallelTest {
+		t.Parallel()
+	}
 	fired := false
 	loop := NewEventLoop()
 	loop.SetTimeout(func(*goja.Runtime) {
@@ -180,7 +236,9 @@ func TestNativeTimeout(t *testing.T) {
 }
 
 func TestNativeClearTimeout(t *testing.T) {
-	t.Parallel()
+	if parallelTest {
+		t.Parallel()
+	}
 	fired := false
 	loop := NewEventLoop()
 	timer := loop.SetTimeout(func(*goja.Runtime) {
@@ -198,7 +256,9 @@ func TestNativeClearTimeout(t *testing.T) {
 }
 
 func TestNativeInterval(t *testing.T) {
-	t.Parallel()
+	if parallelTest {
+		t.Parallel()
+	}
 	count := 0
 	loop := NewEventLoop()
 	var i *Interval
@@ -218,7 +278,9 @@ func TestNativeInterval(t *testing.T) {
 }
 
 func TestNativeClearInterval(t *testing.T) {
-	t.Parallel()
+	if parallelTest {
+		t.Parallel()
+	}
 	count := 0
 	loop := NewEventLoop()
 	loop.Run(func(*goja.Runtime) {
@@ -235,7 +297,9 @@ func TestNativeClearInterval(t *testing.T) {
 }
 
 func TestSetTimeoutConcurrent(t *testing.T) {
-	t.Parallel()
+	if parallelTest {
+		t.Parallel()
+	}
 	loop := NewEventLoop()
 	loop.Start()
 	ch := make(chan struct{}, 1)
@@ -247,7 +311,9 @@ func TestSetTimeoutConcurrent(t *testing.T) {
 }
 
 func TestClearTimeoutConcurrent(t *testing.T) {
-	t.Parallel()
+	if parallelTest {
+		t.Parallel()
+	}
 	loop := NewEventLoop()
 	loop.Start()
 	timer := loop.SetTimeout(func(*goja.Runtime) {
@@ -260,7 +326,9 @@ func TestClearTimeoutConcurrent(t *testing.T) {
 }
 
 func TestClearIntervalConcurrent(t *testing.T) {
-	t.Parallel()
+	if parallelTest {
+		t.Parallel()
+	}
 	loop := NewEventLoop()
 	loop.Start()
 	ch := make(chan struct{}, 1)
@@ -277,7 +345,9 @@ func TestClearIntervalConcurrent(t *testing.T) {
 }
 
 func TestRunOnStoppedLoop(t *testing.T) {
-	t.Parallel()
+	if parallelTest {
+		t.Parallel()
+	}
 	loop := NewEventLoop()
 	var failed int32
 	done := make(chan struct{})
@@ -291,7 +361,7 @@ func TestRunOnStoppedLoop(t *testing.T) {
 	go func() {
 		for atomic.LoadInt32(&failed) == 0 {
 			loop.RunOnLoop(func(*goja.Runtime) {
-				if !loop.canRun {
+				if !loop.canRun() {
 					atomic.StoreInt32(&failed, 1)
 					close(done)
 					return
@@ -310,7 +380,9 @@ func TestRunOnStoppedLoop(t *testing.T) {
 }
 
 func TestPromise(t *testing.T) {
-	t.Parallel()
+	if parallelTest {
+		t.Parallel()
+	}
 	const SCRIPT = `
 	let result;
 	const p = new Promise((resolve, reject) => {
@@ -344,7 +416,9 @@ func TestPromise(t *testing.T) {
 }
 
 func TestPromiseNative(t *testing.T) {
-	t.Parallel()
+	if parallelTest {
+		t.Parallel()
+	}
 	const SCRIPT = `
 	let result;
 	p.then(value => {


### PR DESCRIPTION
If we calling `EventLoop.Stop` on a stopped loop, it will hang.

> Calling Stop() on an already stopped loop or inside the loop will hang.

And if all goroutines are hanging:
```
fatal error: all goroutines are asleep - deadlock!
```
I fixed `EventLoop.Stop` on call on a stopped loop, it will never hang now.