### PR TITLE
Fix errors in import errors

### DIFF
--- a/require/resolve.go
+++ b/require/resolve.go
@@ -40,6 +40,8 @@ func (r *RequireModule) resolve(modpath string) (module *js.Object, err error) {
 		module, err = r.loadNative(origPath)
 		if err == nil {
 			return
+		} else {
+			err = nil
 		}
 		if module = r.nodeModules[p]; module != nil {
 			return


### PR DESCRIPTION
The following change was introduced that changed the order of imports. We must ensure that `err` is reset to avoid a loaded module be returned with an error and a module.

https://github.com/dop251/goja_nodejs/compare/master...etiennemartin:import-error-bleeding?expand=1#diff-92c699c02d3171da6c665dcf868f7278657072b1ddfafad974b00d01650de102R47

The line above will return the loaded `module` and the `err` from previous calls.

This was found by both @iyaz-shaikh and I.