### PR TITLE
Implement setImmediate

### DIFF
--- a/eventloop/eventloop.go
+++ b/eventloop/eventloop.go
@@ -103,7 +103,7 @@ func (loop *EventLoop) schedule(call goja.FunctionCall, repeating bool) goja.Val
 		delay := call.Argument(1).ToInteger()
 		var args []goja.Value
 		if len(call.Arguments) > 2 {
-			args = call.Arguments[2:]
+			args = append(args, call.Arguments[2:]...)
 		}
 		f := func() { fn(nil, args...) }
 		loop.jobCount++

--- a/eventloop/eventloop_test.go
+++ b/eventloop/eventloop_test.go
@@ -76,6 +76,34 @@ func TestInterval(t *testing.T) {
 	})
 }
 
+func TestImmediate(t *testing.T) {
+	t.Parallel()
+	const SCRIPT = `
+	var cb = function(arg) {
+		console.log(arg);
+	}
+	var i;
+	var t = setImmediate(function() {
+		console.log("tick");
+		setImmediate(cb, "tick 2");
+		i = setImmediate(cb, "should not run")
+	});
+	setImmediate(function() {
+		clearImmediate(i);
+	});
+	console.log("Started");
+	`
+
+	loop := NewEventLoop()
+	prg, err := goja.Compile("main.js", SCRIPT, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	loop.Run(func(vm *goja.Runtime) {
+		vm.RunProgram(prg)
+	})
+}
+
 func TestRunNoSchedule(t *testing.T) {
 	loop := NewEventLoop()
 	fired := false

--- a/eventloop/eventloop_test.go
+++ b/eventloop/eventloop_test.go
@@ -57,12 +57,12 @@ func TestInterval(t *testing.T) {
 	t.Parallel()
 	const SCRIPT = `
 	var count = 0;
-	var t = setInterval(function() {
+	var t = setInterval(function(times) {
 		console.log("tick");
-		if (++count > 2) {
+		if (++count > times) {
 			clearInterval(t);
 		}
-	}, 1000);
+	}, 1000, 2);
 	console.log("Started");
 	`
 


### PR DESCRIPTION
As proposed by me in #47, I'm implementing `setImmediate`/`clearImmediate` support matching the [Node.js semantics](https://nodejs.org/api/timers.html#setimmediatecallback-args).

I'm also fixing a bug in argument propagation to the callbacks of `setTimeout` and `setInterval` that had to do with reusing slice references from a different scope (the slice `call.Arguments` of a `goja.FunctionCall` apparently should not be referenced after the call is handled).

I've added/changed tests to validate my changes.