### PR TITLE
Update the console module to behave similarly as in Node.js

### DIFF
--- a/console/module.go
+++ b/console/module.go
@@ -1,8 +1,6 @@
 package console
 
 import (
-	"log"
-
 	"github.com/dop251/goja"
 	"github.com/dop251/goja_nodejs/require"
 	"github.com/dop251/goja_nodejs/util"
@@ -22,16 +20,6 @@ type Printer interface {
 	Error(string)
 }
 
-type PrinterFunc func(s string)
-
-func (p PrinterFunc) Log(s string) { p(s) }
-
-func (p PrinterFunc) Warn(s string) { p(s) }
-
-func (p PrinterFunc) Error(s string) { p(s) }
-
-var defaultPrinter Printer = PrinterFunc(func(s string) { log.Print(s) })
-
 func (c *Console) log(p func(string)) func(goja.FunctionCall) goja.Value {
 	return func(call goja.FunctionCall) goja.Value {
 		if format, ok := goja.AssertFunction(c.util.Get("format")); ok {
@@ -50,7 +38,7 @@ func (c *Console) log(p func(string)) func(goja.FunctionCall) goja.Value {
 }
 
 func Require(runtime *goja.Runtime, module *goja.Object) {
-	requireWithPrinter(defaultPrinter)(runtime, module)
+	requireWithPrinter(defaultStdPrinter)(runtime, module)
 }
 
 func RequireWithPrinter(printer Printer) require.ModuleLoader {
@@ -70,6 +58,8 @@ func requireWithPrinter(printer Printer) require.ModuleLoader {
 		o.Set("log", c.log(c.printer.Log))
 		o.Set("error", c.log(c.printer.Error))
 		o.Set("warn", c.log(c.printer.Warn))
+		o.Set("info", c.log(c.printer.Log))
+		o.Set("debug", c.log(c.printer.Log))
 	}
 }
 

--- a/console/std_printer.go
+++ b/console/std_printer.go
@@ -1,0 +1,38 @@
+package console
+
+import (
+	"log"
+	"os"
+)
+
+var (
+	stderrLogger = log.Default() // the default logger output to stderr
+	stdoutLogger = log.New(os.Stdout, "", log.LstdFlags)
+
+	defaultStdPrinter Printer = &StdPrinter{
+		StdoutPrint: func(s string) { stdoutLogger.Print(s) },
+		StderrPrint: func(s string) { stderrLogger.Print(s) },
+	}
+)
+
+// StdPrinter implements the console.Printer interface
+// that prints to the stdout or stderr.
+type StdPrinter struct {
+	StdoutPrint func(s string)
+	StderrPrint func(s string)
+}
+
+// Log prints s to the stdout.
+func (p StdPrinter) Log(s string) {
+	p.StdoutPrint(s)
+}
+
+// Warn prints s to the stderr.
+func (p StdPrinter) Warn(s string) {
+	p.StderrPrint(s)
+}
+
+// Error prints s to the stderr.
+func (p StdPrinter) Error(s string) {
+	p.StderrPrint(s)
+}


### PR DESCRIPTION
The default Go logger always print to stderr.

This PR changes the default `console` module printer to use stdout or stderr similarly as in Node.js. It also adds the `console.info` and `console.debug` aliases.

Based on the Node.js `console` module docs:
- [console.log](https://nodejs.dev/en/api/v20/console/#consolelogdata-args) prints to `stdout`
- [console.error](https://nodejs.dev/en/api/v20/console/#consoleerrordata-args) prints to `stderr`
- [console.info](https://nodejs.dev/en/api/v20/console/#consoleinfodata-args) alias to `log`; prints to `stdout`
- [console.debug](https://nodejs.dev/en/api/v20/console/#consoledebugdata-args) alias to `log`; prints to `stdout`
- [console.warn](https://nodejs.dev/en/api/v20/console/#consolewarndata-args) alias to `error`; prints to `stderr`

The existing `Printer` interface is not modified to minimize the breaking changes, but still in some situations this could be a breaking change if someone relies on the existing logs destination, so I will understand if you don't want to merge it.

_Just to for more context, this was reported in https://github.com/pocketbase/pocketbase/discussions/3024#discussioncomment-6591840 as the user wasn't expecting the `console.log` messages to end up in their stderr file._
