### PR TITLE
Added Windows paths support when requiring local files

### DIFF
--- a/require/module_test.go
+++ b/require/module_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path"
+	"path/filepath"
 	"testing"
 
 	js "github.com/dop251/goja"
@@ -191,6 +192,34 @@ func TestRequire(t *testing.T) {
 
 	registry := new(Registry)
 	registry.Enable(vm)
+
+	v, err := vm.RunString(SCRIPT)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !v.StrictEquals(vm.ToValue("passed")) {
+		t.Fatalf("Unexpected result: %v", v)
+	}
+}
+
+func TestRequireAbsPath(t *testing.T) {
+	const SCRIPT = `
+	var m = require(absPath);
+	m.test();
+	`
+
+	absPath, err := filepath.Abs("./testdata/m.js")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	vm := js.New()
+
+	registry := new(Registry)
+	registry.Enable(vm)
+
+	vm.Set("absPath", absPath)
 
 	v, err := vm.RunString(SCRIPT)
 	if err != nil {

--- a/require/resolve.go
+++ b/require/resolve.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"path"
+	"path/filepath"
 	"strings"
 
 	js "github.com/dop251/goja"
@@ -28,9 +29,12 @@ func (r *RequireModule) resolve(modpath string) (module *js.Object, err error) {
 	}
 
 	p := path.Join(start, modpath)
-	if strings.HasPrefix(origPath, "./") ||
-		strings.HasPrefix(origPath, "/") || strings.HasPrefix(origPath, "../") ||
-		origPath == "." || origPath == ".." {
+	if origPath == "." || origPath == ".." ||
+		strings.HasPrefix(origPath, "/") ||
+		strings.HasPrefix(origPath, "./") ||
+		strings.HasPrefix(origPath, "../") ||
+		// as last resort check if it is OS specific absolute path (eg. `C:\...`)
+		filepath.IsAbs(origPath) {
 		if module = r.modules[p]; module != nil {
 			return
 		}


### PR DESCRIPTION
This PR adds a OS dependent absolute path check when requiring local files in order to support Windows absolute paths (eg. `C:\...`).

Couple notes:

- I'm not sure actually if this should be allowed because the [node file modules docs](https://nodejs.org/api/modules.html#file-modules) doesn't mention explicitly whether Windows abs path are resolvable or not (or at least I couldn't find).
 I've tested with Windows 10 VM and Node 18 and `require("C:\\...")` works there.

- I'm not sure whether the OS specific separators for `./` and `../` should also be added.


_Edit: for more context, this was reported in https://github.com/pocketbase/pocketbase/issues/3163._