### PR TITLE
fix: UrlSearchParams being overwritten

### DIFF
--- a/url/testdata/url_search_params.js
+++ b/url/testdata/url_search_params.js
@@ -300,8 +300,15 @@ assert.sameValue(params instanceof URLSearchParams, true);
 
 {
     const url = new URL("https://test.com/");
+    url.searchParams.append("a", "1");
+    url.searchParams.append("b", "1");
+    assert.sameValue(url.toString(), "https://test.com/?a=1&b=1");
+}
+
+{
+    const url = new URL("https://test.com/");
     const params = url.searchParams;
-    params.append("a", "1");
+    url.searchParams.append("a", "1");
     assert.sameValue(url.search, "?a=1");
 }
 
@@ -317,6 +324,13 @@ assert.sameValue(params instanceof URLSearchParams, true);
     const params = url.searchParams;
     params.set("a", "1");
     assert.sameValue(url.search, "?a=1");
+}
+
+{
+    const url = new URL("https://test.com/");
+    url.searchParams.set("a", "1");
+    url.searchParams.set("b", "1");
+    assert.sameValue(url.toString(), "https://test.com/?a=1&b=1");
 }
 
 {

--- a/url/url.go
+++ b/url/url.go
@@ -344,11 +344,13 @@ func (m *urlModule) createURLPrototype() *goja.Object {
 
 	// search Params
 	m.defineURLAccessorProp(p, "searchParams", func(u *nodeURL) interface{} {
-		sp := parseSearchQuery(u.url.RawQuery)
-		if sp == nil {
-			sp = make(searchParams, 0)
+		if u.searchParams == nil {
+			sp := parseSearchQuery(u.url.RawQuery)
+			if sp == nil {
+				sp = make(searchParams, 0)
+			}
+			u.searchParams = sp
 		}
-		u.searchParams = sp
 		return m.newURLSearchParams((*urlSearchParams)(u))
 	}, nil)
 


### PR DESCRIPTION
I found a problem that if you make multiple assignments directly with url.searchParams, it overwrites the previous ones, see below code:

```
const url = new URL("https://test.com/");
url.searchParams.set("a", "1");
url.searchParams.set("b", "1");

// expect https://test.com/?a=1&b=1 but print https://test.com/?b=1
console.log(url.toString());
```