### PR TITLE
Support For Custom Extensions Module Loading

### DIFF
--- a/require/module.go
+++ b/require/module.go
@@ -38,8 +38,9 @@ type Registry struct {
 	native   map[string]ModuleLoader
 	compiled map[string]*js.Program
 
-	srcLoader     SourceLoader
-	globalFolders []string
+	srcLoader      SourceLoader
+	globalFolders  []string
+	loadExtensions []string
 }
 
 type RequireModule struct {
@@ -85,6 +86,15 @@ func WithLoader(srcLoader SourceLoader) Option {
 func WithGlobalFolders(globalFolders ...string) Option {
 	return func(r *Registry) {
 		r.globalFolders = globalFolders
+	}
+}
+
+// WithLoadExtensions sets a list of extensions to try while loading module files
+// Definition order matters as the first matched extension would be used as a result
+// Default extensions are defined as [".js", ".json"] at DefaultModuleExtensions variable
+func WithLoadExtensions(loadExtensions ...string) Option {
+	return func(r *Registry) {
+		r.loadExtensions = loadExtensions
 	}
 }
 


### PR DESCRIPTION
Hi.
This allows to customize file extensions to be loaded for the Registry.


As an alternative it is really possible to handle this on a `srcLoader` level.  
Still it could be useful to address this in general for the cases like
```go
WithLoadExtensions(".mjs", ".js", ".json"),
WithLoader(func(name string) ([]byte, error) {
        if /* some custom condition */ {
	        // some custom implementation
        }
        // Fallback. for default loader
        return require.DefaultSourceLoader(name)
}),
```

