### PR TITLE
Added StartLooping to eventloop

### DIFF
--- a/eventloop/eventloop.go
+++ b/eventloop/eventloop.go
@@ -211,6 +211,13 @@ func (loop *EventLoop) Start() {
 	go loop.run(true)
 }
 
+// StartLooping starts the event loop in the current goroutine. The loop continues to run until Stop() is called.
+// If the loop is already started it will panic.
+func (loop *EventLoop) StartLooping() {
+	loop.setRunning()
+	loop.run(true)
+}
+
 // Stop the loop that was started with Start(). After this function returns there will be no more jobs executed
 // by the loop. It is possible to call Start() or Run() again after this to resume the execution.
 // Note, it does not cancel active timeouts.

--- a/eventloop/eventloop_test.go
+++ b/eventloop/eventloop_test.go
@@ -89,6 +89,49 @@ func TestStart(t *testing.T) {
 	}
 }
 
+func TestStartLooping(t *testing.T) {
+	t.Parallel()
+	const SCRIPT = `
+	var calledAt;
+	setTimeout(function() {
+		calledAt = now();
+	}, 1000);
+	`
+
+	prg, err := goja.Compile("main.js", SCRIPT, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	loop := NewEventLoop()
+	startTime := time.Now()
+	go loop.StartLooping()
+
+	loop.RunOnLoop(func(vm *goja.Runtime) {
+		vm.Set("now", time.Now)
+		vm.RunProgram(prg)
+	})
+
+	time.Sleep(2 * time.Second)
+	if remainingJobs := loop.Stop(); remainingJobs != 0 {
+		t.Fatal(remainingJobs)
+	}
+
+	var calledAt time.Time
+	loop.Run(func(vm *goja.Runtime) {
+		err = vm.ExportTo(vm.Get("calledAt"), &calledAt)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if calledAt.IsZero() {
+		t.Fatal("Not called")
+	}
+	if dur := calledAt.Sub(startTime); dur < time.Second {
+		t.Fatal(dur)
+	}
+}
+
 func TestInterval(t *testing.T) {
 	t.Parallel()
 	const SCRIPT = `


### PR DESCRIPTION
# Problem
The application I'm working on right now has some logic that will recover from panics at the highest level to perform some additional logging (mostly of internal state that we'll need to use later as part of recovering from unplanned downtime).

For our scripting interface, we're generally able to manage panics that arise from go calls in our scripts if they happen within a synchronous call (i.e. RunOnLoop & RunProgram calls) but if the problematic code executes in a background event loop during a setTimeout we're currently unable to perform our shutdown tasks. 

We do have a workaround at the moment by just spawning a goroutine to call `Run` with an empty function

```
	go func() {
		defer func() {
			if rec := recover(); rec != nil {
				// Call Panic Recovery
			}
		}()

		for {
			loop.Run(func(vm *goja.Runtime) {
				// Tick
			})
		}
	}() 
```

However this feels a bit hacky

# Proposed Solution

Simply provide an interface for calling the loop directly in the current goroutine

```
func (loop *EventLoop) StartLooping() {
	loop.setRunning()
	loop.run(true)
}
```

---

Admittedly, this might be somewhat of a niche problem, or it might be that our current solution is the intended interface but I figured I'd open a PR as a starting point for discussion.

Let me know if you have any thoughts or would prefer another route for solving this problem -- I'm happy to contribute any way I can!