### PR TITLE
Added all the fixed size `Buffer.read*` methods

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Run staticcheck
         uses: dominikh/staticcheck-action@v1.3.1
         with:
-          version: "2023.1.7"
+          version: "2024.1.1"
           install-go: false
           cache-key: ${{ matrix.go-version }}
         if: ${{ matrix.go-version == '1.x' }}

--- a/buffer/buffer.go
+++ b/buffer/buffer.go
@@ -3,7 +3,10 @@ package buffer
 import (
 	"bytes"
 	"encoding/base64"
+	"encoding/binary"
 	"encoding/hex"
+	"math"
+	"math/big"
 	"reflect"
 	"strconv"
 
@@ -404,6 +407,167 @@ func (b *Buffer) proto_equals(call goja.FunctionCall) goja.Value {
 	panic(errors.NewTypeError(b.r, errors.ErrCodeInvalidArgType, "The \"otherBuffer\" argument must be an instance of Buffer or Uint8Array."))
 }
 
+// readBigInt64BE reads a big-endian 64-bit signed integer from the buffer
+func (b *Buffer) readBigInt64BE(call goja.FunctionCall) goja.Value {
+	return b.readFixedLengthValue(call, 8, func(bb []byte) any {
+		value := int64(binary.BigEndian.Uint64(bb))
+		return big.NewInt(value)
+	})
+}
+
+// readBigInt64LE reads a little-endian 64-bit signed integer from the buffer
+func (b *Buffer) readBigInt64LE(call goja.FunctionCall) goja.Value {
+	return b.readFixedLengthValue(call, 8, func(bb []byte) any {
+		value := int64(binary.LittleEndian.Uint64(bb))
+		return big.NewInt(value)
+	})
+}
+
+// readBigUInt64BE reads a big-endian 64-bit unsigned integer from the buffer
+func (b *Buffer) readBigUInt64BE(call goja.FunctionCall) goja.Value {
+	return b.readFixedLengthValue(call, 8, func(bb []byte) any {
+		value := binary.BigEndian.Uint64(bb)
+		return new(big.Int).SetUint64(value)
+	})
+}
+
+// readBigUInt64LE reads a little-endian 64-bit unsigned integer from the buffer
+func (b *Buffer) readBigUInt64LE(call goja.FunctionCall) goja.Value {
+	return b.readFixedLengthValue(call, 8, func(bb []byte) any {
+		value := binary.LittleEndian.Uint64(bb)
+		return new(big.Int).SetUint64(value)
+	})
+}
+
+// readDoubleBE reads a big-endian 64-bit floating-point number from the buffer
+func (b *Buffer) readDoubleBE(call goja.FunctionCall) goja.Value {
+	return b.readFixedLengthValue(call, 8, func(bb []byte) any {
+		value := binary.BigEndian.Uint64(bb)
+		return math.Float64frombits(value)
+	})
+}
+
+// readDoubleLE reads a little-endian 64-bit floating-point number from the buffer
+func (b *Buffer) readDoubleLE(call goja.FunctionCall) goja.Value {
+	return b.readFixedLengthValue(call, 8, func(bb []byte) any {
+		value := binary.LittleEndian.Uint64(bb)
+		return math.Float64frombits(value)
+	})
+}
+
+// readFloatBE reads a big-endian 32-bit floating-point number from the buffer
+func (b *Buffer) readFloatBE(call goja.FunctionCall) goja.Value {
+	return b.readFixedLengthValue(call, 4, func(bb []byte) any {
+		value := binary.BigEndian.Uint32(bb)
+		return math.Float32frombits(value)
+	})
+}
+
+// readFloatLE reads a little-endian 32-bit floating-point number from the buffer
+func (b *Buffer) readFloatLE(call goja.FunctionCall) goja.Value {
+	return b.readFixedLengthValue(call, 4, func(bb []byte) any {
+		value := binary.LittleEndian.Uint32(bb)
+		return math.Float32frombits(value)
+	})
+}
+
+// readInt8 reads an 8-bit signed integer from the buffer
+func (b *Buffer) readInt8(call goja.FunctionCall) goja.Value {
+	return b.readFixedLengthValue(call, 1, func(bb []byte) any {
+		return int8(bb[0])
+	})
+}
+
+// readInt16BE reads a big-endian 16-bit signed integer from the buffer
+func (b *Buffer) readInt16BE(call goja.FunctionCall) goja.Value {
+	return b.readFixedLengthValue(call, 2, func(bb []byte) any {
+		return int16(binary.BigEndian.Uint16(bb))
+	})
+}
+
+// readInt16LE reads a little-endian 16-bit signed integer from the buffer
+func (b *Buffer) readInt16LE(call goja.FunctionCall) goja.Value {
+	return b.readFixedLengthValue(call, 2, func(bb []byte) any {
+		return int16(binary.LittleEndian.Uint16(bb))
+	})
+}
+
+// readInt32BE reads a big-endian 32-bit signed integer from the buffer
+func (b *Buffer) readInt32BE(call goja.FunctionCall) goja.Value {
+	return b.readFixedLengthValue(call, 4, func(bb []byte) any {
+		return binary.BigEndian.Uint32(bb)
+	})
+}
+
+// readInt32LE reads a little-endian 32-bit signed integer from the buffer
+func (b *Buffer) readInt32LE(call goja.FunctionCall) goja.Value {
+	return b.readFixedLengthValue(call, 4, func(bb []byte) any {
+		return binary.LittleEndian.Uint32(bb)
+	})
+}
+
+// readUInt8 reads an 8-bit unsigned integer from the buffer
+func (b *Buffer) readUInt8(call goja.FunctionCall) goja.Value {
+	return b.readFixedLengthValue(call, 1, func(bb []byte) any {
+		return bb[0]
+	})
+}
+
+// readUInt16BE reads a big-endian 16-bit unsigned integer from the buffer
+func (b *Buffer) readUInt16BE(call goja.FunctionCall) goja.Value {
+	return b.readFixedLengthValue(call, 2, func(bb []byte) any {
+		return binary.BigEndian.Uint16(bb)
+	})
+}
+
+// readUInt16LE reads a little-endian 16-bit unsigned integer from the buffer
+func (b *Buffer) readUInt16LE(call goja.FunctionCall) goja.Value {
+	return b.readFixedLengthValue(call, 2, func(bb []byte) any {
+		return binary.LittleEndian.Uint16(bb)
+	})
+}
+
+// readUInt32BE reads a big-endian 32-bit unsigned integer from the buffer
+func (b *Buffer) readUInt32BE(call goja.FunctionCall) goja.Value {
+	return b.readFixedLengthValue(call, 4, func(bb []byte) any {
+		return binary.BigEndian.Uint32(bb)
+	})
+}
+
+// readUInt32LE reads a little-endian 32-bit unsigned integer from the buffer
+func (b *Buffer) readUInt32LE(call goja.FunctionCall) goja.Value {
+	return b.readFixedLengthValue(call, 4, func(bb []byte) any {
+		return binary.LittleEndian.Uint32(bb)
+	})
+}
+
+func (b *Buffer) readFixedLengthValue(call goja.FunctionCall, numBytes int64, convert func(b []byte) any) goja.Value {
+	bb := Bytes(b.r, call.This)
+	offset := b.getOffsetArgument(call, 0, bb, numBytes)
+	value := convert(bb[offset : offset+numBytes])
+
+	return b.r.ToValue(value)
+}
+
+func (b *Buffer) getOffsetArgument(call goja.FunctionCall, argIndex int, bb []byte, numBytes int64) int64 {
+	arg := call.Argument(argIndex)
+	var offset int64
+	if isNumber(arg) {
+		offset = arg.ToInteger()
+	} else if goja.IsUndefined(arg) {
+		// optional arg that defaults to zero
+		offset = 0
+	} else {
+		panic(errors.NewTypeError(b.r, errors.ErrCodeInvalidArgType, "The \"offset\" argument must be of type number."))
+	}
+
+	if offset < 0 || offset+numBytes > int64(len(bb)) {
+		panic(errors.NewError(b.r, nil, errors.ErrCodedOutOfRange, "The value of \"offset\" %d is out of range", offset))
+	}
+
+	return offset
+}
+
 func Require(runtime *goja.Runtime, module *goja.Object) {
 	b := &Buffer{r: runtime}
 	uint8Array := runtime.Get("Uint8Array")
@@ -425,6 +589,24 @@ func Require(runtime *goja.Runtime, module *goja.Object) {
 	proto.DefineDataProperty("constructor", ctor, goja.FLAG_TRUE, goja.FLAG_TRUE, goja.FLAG_FALSE)
 	proto.Set("equals", b.proto_equals)
 	proto.Set("toString", b.proto_toString)
+	proto.Set("readBigInt64BE", b.readBigInt64BE)
+	proto.Set("readBigInt64LE", b.readBigInt64LE)
+	proto.Set("readBigUInt64BE", b.readBigUInt64BE)
+	proto.Set("readBigUInt64LE", b.readBigUInt64LE)
+	proto.Set("readDoubleBE", b.readDoubleBE)
+	proto.Set("readDoubleLE", b.readDoubleLE)
+	proto.Set("readFloatBE", b.readFloatBE)
+	proto.Set("readFloatLE", b.readFloatLE)
+	proto.Set("readInt8", b.readInt8)
+	proto.Set("readInt16BE", b.readInt16BE)
+	proto.Set("readInt16LE", b.readInt16LE)
+	proto.Set("readInt32BE", b.readInt32BE)
+	proto.Set("readInt32LE", b.readInt32LE)
+	proto.Set("readUInt8", b.readUInt8)
+	proto.Set("readUInt16BE", b.readUInt16BE)
+	proto.Set("readUInt16LE", b.readUInt16LE)
+	proto.Set("readUInt32BE", b.readUInt32BE)
+	proto.Set("readUInt32LE", b.readUInt32LE)
 
 	ctor.Set("prototype", proto)
 	ctor.Set("poolSize", 8192)

--- a/buffer/buffer.go
+++ b/buffer/buffer.go
@@ -409,142 +409,162 @@ func (b *Buffer) proto_equals(call goja.FunctionCall) goja.Value {
 
 // readBigInt64BE reads a big-endian 64-bit signed integer from the buffer
 func (b *Buffer) readBigInt64BE(call goja.FunctionCall) goja.Value {
-	return b.readFixedLengthValue(call, 8, func(bb []byte) any {
-		value := int64(binary.BigEndian.Uint64(bb))
-		return big.NewInt(value)
-	})
+	bb := Bytes(b.r, call.This)
+	offset := b.getOffsetArgument(call, 0, bb, 8)
+	value := int64(binary.BigEndian.Uint64(bb[offset : offset+8]))
+
+	return b.r.ToValue(big.NewInt(value))
 }
 
 // readBigInt64LE reads a little-endian 64-bit signed integer from the buffer
 func (b *Buffer) readBigInt64LE(call goja.FunctionCall) goja.Value {
-	return b.readFixedLengthValue(call, 8, func(bb []byte) any {
-		value := int64(binary.LittleEndian.Uint64(bb))
-		return big.NewInt(value)
-	})
+	bb := Bytes(b.r, call.This)
+	offset := b.getOffsetArgument(call, 0, bb, 8)
+	value := int64(binary.LittleEndian.Uint64(bb[offset : offset+8]))
+
+	return b.r.ToValue(big.NewInt(value))
 }
 
 // readBigUInt64BE reads a big-endian 64-bit unsigned integer from the buffer
 func (b *Buffer) readBigUInt64BE(call goja.FunctionCall) goja.Value {
-	return b.readFixedLengthValue(call, 8, func(bb []byte) any {
-		value := binary.BigEndian.Uint64(bb)
-		return new(big.Int).SetUint64(value)
-	})
+	bb := Bytes(b.r, call.This)
+	offset := b.getOffsetArgument(call, 0, bb, 8)
+	value := binary.BigEndian.Uint64(bb[offset : offset+8])
+
+	return b.r.ToValue(new(big.Int).SetUint64(value))
 }
 
 // readBigUInt64LE reads a little-endian 64-bit unsigned integer from the buffer
 func (b *Buffer) readBigUInt64LE(call goja.FunctionCall) goja.Value {
-	return b.readFixedLengthValue(call, 8, func(bb []byte) any {
-		value := binary.LittleEndian.Uint64(bb)
-		return new(big.Int).SetUint64(value)
-	})
+	bb := Bytes(b.r, call.This)
+	offset := b.getOffsetArgument(call, 0, bb, 8)
+	value := binary.LittleEndian.Uint64(bb[offset : offset+8])
+
+	return b.r.ToValue(new(big.Int).SetUint64(value))
 }
 
 // readDoubleBE reads a big-endian 64-bit floating-point number from the buffer
 func (b *Buffer) readDoubleBE(call goja.FunctionCall) goja.Value {
-	return b.readFixedLengthValue(call, 8, func(bb []byte) any {
-		value := binary.BigEndian.Uint64(bb)
-		return math.Float64frombits(value)
-	})
+	bb := Bytes(b.r, call.This)
+	offset := b.getOffsetArgument(call, 0, bb, 8)
+	value := binary.BigEndian.Uint64(bb[offset : offset+8])
+
+	return b.r.ToValue(math.Float64frombits(value))
 }
 
 // readDoubleLE reads a little-endian 64-bit floating-point number from the buffer
 func (b *Buffer) readDoubleLE(call goja.FunctionCall) goja.Value {
-	return b.readFixedLengthValue(call, 8, func(bb []byte) any {
-		value := binary.LittleEndian.Uint64(bb)
-		return math.Float64frombits(value)
-	})
+	bb := Bytes(b.r, call.This)
+	offset := b.getOffsetArgument(call, 0, bb, 8)
+	value := binary.LittleEndian.Uint64(bb[offset : offset+8])
+
+	return b.r.ToValue(math.Float64frombits(value))
 }
 
 // readFloatBE reads a big-endian 32-bit floating-point number from the buffer
 func (b *Buffer) readFloatBE(call goja.FunctionCall) goja.Value {
-	return b.readFixedLengthValue(call, 4, func(bb []byte) any {
-		value := binary.BigEndian.Uint32(bb)
-		return math.Float32frombits(value)
-	})
+	bb := Bytes(b.r, call.This)
+	offset := b.getOffsetArgument(call, 0, bb, 4)
+	value := binary.BigEndian.Uint32(bb[offset : offset+4])
+
+	return b.r.ToValue(math.Float32frombits(value))
 }
 
 // readFloatLE reads a little-endian 32-bit floating-point number from the buffer
 func (b *Buffer) readFloatLE(call goja.FunctionCall) goja.Value {
-	return b.readFixedLengthValue(call, 4, func(bb []byte) any {
-		value := binary.LittleEndian.Uint32(bb)
-		return math.Float32frombits(value)
-	})
+	bb := Bytes(b.r, call.This)
+	offset := b.getOffsetArgument(call, 0, bb, 4)
+	value := binary.LittleEndian.Uint32(bb[offset : offset+4])
+
+	return b.r.ToValue(math.Float32frombits(value))
 }
 
 // readInt8 reads an 8-bit signed integer from the buffer
 func (b *Buffer) readInt8(call goja.FunctionCall) goja.Value {
-	return b.readFixedLengthValue(call, 1, func(bb []byte) any {
-		return int8(bb[0])
-	})
+	bb := Bytes(b.r, call.This)
+	offset := b.getOffsetArgument(call, 0, bb, 1)
+	value := int8(bb[offset])
+
+	return b.r.ToValue(value)
 }
 
 // readInt16BE reads a big-endian 16-bit signed integer from the buffer
 func (b *Buffer) readInt16BE(call goja.FunctionCall) goja.Value {
-	return b.readFixedLengthValue(call, 2, func(bb []byte) any {
-		return int16(binary.BigEndian.Uint16(bb))
-	})
+	bb := Bytes(b.r, call.This)
+	offset := b.getOffsetArgument(call, 0, bb, 2)
+	value := int16(binary.BigEndian.Uint16(bb[offset : offset+2]))
+
+	return b.r.ToValue(value)
 }
 
 // readInt16LE reads a little-endian 16-bit signed integer from the buffer
 func (b *Buffer) readInt16LE(call goja.FunctionCall) goja.Value {
-	return b.readFixedLengthValue(call, 2, func(bb []byte) any {
-		return int16(binary.LittleEndian.Uint16(bb))
-	})
+	bb := Bytes(b.r, call.This)
+	offset := b.getOffsetArgument(call, 0, bb, 2)
+	value := int16(binary.LittleEndian.Uint16(bb[offset : offset+2]))
+
+	return b.r.ToValue(value)
 }
 
 // readInt32BE reads a big-endian 32-bit signed integer from the buffer
 func (b *Buffer) readInt32BE(call goja.FunctionCall) goja.Value {
-	return b.readFixedLengthValue(call, 4, func(bb []byte) any {
-		return binary.BigEndian.Uint32(bb)
-	})
+	bb := Bytes(b.r, call.This)
+	offset := b.getOffsetArgument(call, 0, bb, 4)
+	value := int32(binary.BigEndian.Uint32(bb[offset : offset+4]))
+
+	return b.r.ToValue(value)
 }
 
 // readInt32LE reads a little-endian 32-bit signed integer from the buffer
 func (b *Buffer) readInt32LE(call goja.FunctionCall) goja.Value {
-	return b.readFixedLengthValue(call, 4, func(bb []byte) any {
-		return binary.LittleEndian.Uint32(bb)
-	})
+	bb := Bytes(b.r, call.This)
+	offset := b.getOffsetArgument(call, 0, bb, 4)
+	value := int32(binary.LittleEndian.Uint32(bb[offset : offset+4]))
+
+	return b.r.ToValue(value)
 }
 
 // readUInt8 reads an 8-bit unsigned integer from the buffer
 func (b *Buffer) readUInt8(call goja.FunctionCall) goja.Value {
-	return b.readFixedLengthValue(call, 1, func(bb []byte) any {
-		return bb[0]
-	})
+	bb := Bytes(b.r, call.This)
+	offset := b.getOffsetArgument(call, 0, bb, 1)
+	value := bb[offset]
+
+	return b.r.ToValue(value)
 }
 
 // readUInt16BE reads a big-endian 16-bit unsigned integer from the buffer
 func (b *Buffer) readUInt16BE(call goja.FunctionCall) goja.Value {
-	return b.readFixedLengthValue(call, 2, func(bb []byte) any {
-		return binary.BigEndian.Uint16(bb)
-	})
+	bb := Bytes(b.r, call.This)
+	offset := b.getOffsetArgument(call, 0, bb, 2)
+	value := binary.BigEndian.Uint16(bb[offset : offset+2])
+
+	return b.r.ToValue(value)
 }
 
 // readUInt16LE reads a little-endian 16-bit unsigned integer from the buffer
 func (b *Buffer) readUInt16LE(call goja.FunctionCall) goja.Value {
-	return b.readFixedLengthValue(call, 2, func(bb []byte) any {
-		return binary.LittleEndian.Uint16(bb)
-	})
+	bb := Bytes(b.r, call.This)
+	offset := b.getOffsetArgument(call, 0, bb, 2)
+	value := binary.LittleEndian.Uint16(bb[offset : offset+2])
+
+	return b.r.ToValue(value)
 }
 
 // readUInt32BE reads a big-endian 32-bit unsigned integer from the buffer
 func (b *Buffer) readUInt32BE(call goja.FunctionCall) goja.Value {
-	return b.readFixedLengthValue(call, 4, func(bb []byte) any {
-		return binary.BigEndian.Uint32(bb)
-	})
+	bb := Bytes(b.r, call.This)
+	offset := b.getOffsetArgument(call, 0, bb, 4)
+	value := binary.BigEndian.Uint32(bb[offset : offset+4])
+
+	return b.r.ToValue(value)
 }
 
 // readUInt32LE reads a little-endian 32-bit unsigned integer from the buffer
 func (b *Buffer) readUInt32LE(call goja.FunctionCall) goja.Value {
-	return b.readFixedLengthValue(call, 4, func(bb []byte) any {
-		return binary.LittleEndian.Uint32(bb)
-	})
-}
-
-func (b *Buffer) readFixedLengthValue(call goja.FunctionCall, numBytes int64, convert func(b []byte) any) goja.Value {
 	bb := Bytes(b.r, call.This)
-	offset := b.getOffsetArgument(call, 0, bb, numBytes)
-	value := convert(bb[offset : offset+numBytes])
+	offset := b.getOffsetArgument(call, 0, bb, 4)
+	value := binary.LittleEndian.Uint32(bb[offset : offset+4])
 
 	return b.r.ToValue(value)
 }

--- a/buffer/buffer_test.go
+++ b/buffer/buffer_test.go
@@ -1,6 +1,8 @@
 package buffer
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/dop251/goja"
@@ -225,4 +227,585 @@ func TestBuffer_alloc(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+}
+
+type testCase struct {
+	name        string
+	script      string
+	expectedErr string
+}
+
+func runTestCases(t *testing.T, tcs []testCase) {
+	vm := goja.New()
+	new(require.Registry).Enable(vm)
+	_, err := vm.RunString(`const Buffer = require("node:buffer").Buffer;`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			template := `
+            {
+				%s
+			}
+            `
+			_, err := vm.RunString(fmt.Sprintf(template, tc.script))
+			if tc.expectedErr != "" {
+				if err == nil {
+					t.Errorf("expected error %q, but got none", tc.expectedErr)
+				} else {
+					if !strings.HasPrefix(err.Error(), tc.expectedErr) {
+						t.Errorf("expected error %q, got %q", tc.expectedErr, err.Error())
+					}
+				}
+			} else {
+				if err != nil {
+					t.Errorf("expected no error, but got %q", err.Error())
+				}
+			}
+		})
+	}
+}
+
+func TestBuffer_readBigInt64BE(t *testing.T) {
+	tcs := []testCase{
+		{
+			name: "with zero offset",
+			script: `
+				const b = Buffer.from([0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff]);
+				if (b.readBigInt64BE(0) !== BigInt(4294967295)) {
+					throw new Error(b);
+				}
+			`,
+		},
+		{
+			name: "with no/default offset",
+			script: `
+				const b = Buffer.from([0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff]);
+				if (b.readBigInt64BE() !== BigInt(4294967295)) {
+					throw new Error(b);
+				}
+			`,
+		},
+	}
+
+	runTestCases(t, tcs)
+}
+
+func TestBuffer_readBigInt64LE(t *testing.T) {
+	tcs := []testCase{
+		{
+			name: "with zero offset",
+			script: `
+				const b = Buffer.from([0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff]);
+				if (b.readBigInt64LE(0) !== BigInt(-4294967296)) {
+					throw new Error(b);
+				}
+			`,
+		},
+		{
+			name: "with out of range offset",
+			script: `
+				const b =  Buffer.from([0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff]);
+				// this should error 
+				b.readBigInt64LE(1);
+				throw new Error("should not get here");
+			`,
+			expectedErr: `Error [ERR_OUT_OF_RANGE]: The value of "offset" 1 is out of range`,
+		},
+	}
+
+	runTestCases(t, tcs)
+}
+
+func TestBuffer_readBigUInt64BE(t *testing.T) {
+	tcs := []testCase{
+		{
+			name: "with zero offset",
+			script: `
+				const b = Buffer.from([0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff]);
+				if (b.readBigUInt64BE(0) !== BigInt(4294967295)) {
+					throw new Error(b);
+				}
+			`,
+		},
+		{
+			name: "with no/default offset",
+			script: `
+				const b = Buffer.from([0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff]);
+				if (b.readBigUInt64BE() !== BigInt(4294967295)) {
+					throw new Error(b);
+				}
+			`,
+		},
+	}
+
+	runTestCases(t, tcs)
+}
+
+func TestBuffer_readBigUInt64LE(t *testing.T) {
+	tcs := []testCase{
+		{
+			name: "with zero offset",
+			script: `
+				const b = Buffer.from([0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff]);
+				if (b.readBigUInt64LE(0) !== BigInt(18446744069414584320)) {
+					throw new Error(b);
+				}
+			`,
+		},
+		{
+			name: "with out of range offset",
+			script: `
+				const b =  Buffer.from([0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff]);
+				// this should error 
+				b.readBigUInt64LE(1);
+				throw new Error("should not get here");
+			`,
+			expectedErr: `Error [ERR_OUT_OF_RANGE]: The value of "offset" 1 is out of range`,
+		},
+	}
+
+	runTestCases(t, tcs)
+}
+
+func TestBuffer_readDoubleBE(t *testing.T) {
+	tcs := []testCase{
+		{
+			name: "with zero offset",
+			script: `
+				const b = Buffer.from([1, 2, 3, 4, 5, 6, 7, 8]);
+				if (b.readDoubleBE(0) !== 8.20788039913184e-304) {
+					throw new Error(b);
+				}
+			`,
+		},
+		{
+			name: "with no/default offset",
+			script: `
+				const b = Buffer.from([1, 2, 3, 4, 5, 6, 7, 8]);
+				if (b.readDoubleBE() !== 8.20788039913184e-304) {
+					throw new Error(b);
+				}
+			`,
+		},
+	}
+
+	runTestCases(t, tcs)
+}
+
+func TestBuffer_readDoubleLE(t *testing.T) {
+	tcs := []testCase{
+		{
+			name: "with zero offset",
+			script: `
+				const b = Buffer.from([1, 2, 3, 4, 5, 6, 7, 8]);
+				if (b.readDoubleLE(0) !== 5.447603722011605e-270) {
+					throw new Error(b);
+				}
+			`,
+		},
+		{
+			name: "with out of range offset",
+			script: `
+				const b = Buffer.from([1, 2, 3, 4, 5, 6, 7, 8]);
+				// this should error 
+				b.readDoubleLE(1);
+				throw new Error("should not get here");
+			`,
+			expectedErr: `Error [ERR_OUT_OF_RANGE]: The value of "offset" 1 is out of range`,
+		},
+	}
+
+	runTestCases(t, tcs)
+}
+
+func TestBuffer_readFloatBE(t *testing.T) {
+	tcs := []testCase{
+		{
+			name: "with zero offset",
+			script: `
+				const b = Buffer.from([1, 2, 3, 4]);
+				if (b.readFloatBE(0) !== 2.387939260590663e-38) {
+					throw new Error(b);
+				}
+			`,
+		},
+		{
+			name: "with no/default offset",
+			script: `
+				const b = Buffer.from([1, 2, 3, 4]);
+				if (b.readFloatBE() !== 2.387939260590663e-38) {
+					throw new Error(b);
+				}
+			`,
+		},
+	}
+
+	runTestCases(t, tcs)
+}
+
+func TestBuffer_readFloatLE(t *testing.T) {
+	tcs := []testCase{
+		{
+			name: "with zero offset",
+			script: `
+				const b = Buffer.from([1, 2, 3, 4]);
+				if (b.readFloatLE(0) !== 1.539989614439558e-36) {
+					throw new Error(b);
+				}
+			`,
+		},
+		{
+			name: "with out of range offset",
+			script: `
+				const b = Buffer.from([1, 2, 3, 4]);
+				// this should error 
+				b.readFloatLE(1);
+				throw new Error("should not get here");
+			`,
+			expectedErr: `Error [ERR_OUT_OF_RANGE]: The value of "offset" 1 is out of range`,
+		},
+	}
+
+	runTestCases(t, tcs)
+}
+
+func TestBuffer_readInt8(t *testing.T) {
+	tcs := []testCase{
+		{
+			name: "with zero offset",
+			script: `
+				const b = Buffer.from([-1, 5]);
+				if (b.readInt8(0) !== -1) {
+					throw new Error(b);
+				}
+			`,
+		},
+		{
+			name: "with last offset",
+			script: `
+				const b = Buffer.from([-1, 5]);
+				if (b.readInt8(1) !== 5) {
+					throw new Error(b);
+				}
+			`,
+		},
+		{
+			name: "with no/default offset",
+			script: `
+				const b = Buffer.from([-1, 5]);
+				if (b.readInt8() !== -1) {
+					throw new Error(b);
+				}
+			`,
+		},
+	}
+
+	runTestCases(t, tcs)
+}
+
+func TestBuffer_readInt16BE(t *testing.T) {
+	tcs := []testCase{
+		{
+			name: "with zero offset",
+			script: `
+				const b = Buffer.from([0, 5]);
+				if (b.readInt16BE(0) !== 5) {
+					throw new Error(b);
+				}
+			`,
+		},
+		{
+			name: "with out of range offset",
+			script: `
+				const b = Buffer.from([0xA, 0x5]);
+				// this should error 
+				b.readInt16BE(1);
+				throw new Error("should not get here");
+			`,
+			expectedErr: `Error [ERR_OUT_OF_RANGE]: The value of "offset" 1 is out of range`,
+		},
+		{
+			name: "with no/default offset",
+			script: `
+				const b = Buffer.from([0, 5]);
+				if (b.readInt16BE() !== 5) {
+					throw new Error(b);
+				}
+			`,
+		},
+	}
+
+	runTestCases(t, tcs)
+}
+
+func TestBuffer_readInt16LE(t *testing.T) {
+	tcs := []testCase{
+		{
+			name: "with zero offset",
+			script: `
+				const b = Buffer.from([0, 5]);
+				if (b.readInt16LE(0) !== 1280) {
+					throw new Error(b);
+				}
+			`,
+		},
+		{
+			name: "with out of range offset",
+			script: `
+				const b = Buffer.from([0, 5]);
+				// this should error 
+				b.readInt16LE(1);
+				throw new Error("should not get here");
+			`,
+			expectedErr: `Error [ERR_OUT_OF_RANGE]: The value of "offset" 1 is out of range`,
+		},
+	}
+
+	runTestCases(t, tcs)
+}
+
+func TestBuffer_readInt32BE(t *testing.T) {
+	tcs := []testCase{
+		{
+			name: "with zero offset",
+			script: `
+				const b = Buffer.from([0, 0, 0, 5]);
+				if (b.readInt32BE(0) !== 5) {
+					throw new Error(b);
+				}
+			`,
+		},
+		{
+			name: "with out of range offset",
+			script: `
+				const b = Buffer.from([0, 0, 0, 5]);
+				// this should error 
+				b.readInt32BE(1);
+				throw new Error("should not get here");
+			`,
+			expectedErr: `Error [ERR_OUT_OF_RANGE]: The value of "offset" 1 is out of range`,
+		},
+		{
+			name: "with no/default offset",
+			script: `
+				const b = Buffer.from([0, 0, 0, 5]);
+				if (b.readInt32BE() !== 5) {
+					throw new Error(b);
+				}
+			`,
+		},
+	}
+
+	runTestCases(t, tcs)
+}
+
+func TestBuffer_readInt32LE(t *testing.T) {
+	tcs := []testCase{
+		{
+			name: "with zero offset",
+			script: `
+				const b = Buffer.from([0, 0, 0, 5]);
+				if (b.readInt32LE(0) !== 83886080) {
+					throw new Error(b);
+				}
+			`,
+		},
+		{
+			name: "with out of range offset",
+			script: `
+				const b = Buffer.from([0, 0, 0, 5]);
+				// this should error 
+				b.readInt32LE(1);
+				throw new Error("should not get here");
+			`,
+			expectedErr: `Error [ERR_OUT_OF_RANGE]: The value of "offset" 1 is out of range`,
+		},
+		{
+			name: "with no/default offset",
+			script: `
+				const b = Buffer.from([0, 0, 0, 5]);
+				if (b.readInt32LE() !== 83886080) {
+					throw new Error(b);
+				}
+			`,
+		},
+	}
+
+	runTestCases(t, tcs)
+}
+
+func TestBuffer_readUInt8(t *testing.T) {
+	tcs := []testCase{
+		{
+			name: "with zero offset",
+			script: `
+				const b = Buffer.from([1, -2]);
+				if (b.readUInt8(0) !== 1) {
+					throw new Error(b);
+				}
+			`,
+		},
+		{
+			name: "with last offset",
+			script: `
+				const b = Buffer.from([1, -2]);
+				if (b.readUInt8(1) !== 254) {
+					throw new Error(b);
+				}
+			`,
+		},
+		{
+			name: "with no/default offset",
+			script: `
+				const b = Buffer.from([1, -2]);
+				if (b.readUInt8() !== 1) {
+					throw new Error(b);
+				}
+			`,
+		},
+	}
+
+	runTestCases(t, tcs)
+}
+
+func TestBuffer_readUInt16BE(t *testing.T) {
+	tcs := []testCase{
+		{
+			name: "with zero offset",
+			script: `
+				const b = Buffer.from([0x12, 0x34, 0x56]);
+				if (b.readUInt16BE(0).toString(16) !== "1234") {
+					throw new Error(b);
+				}
+			`,
+		},
+		{
+			name: "with last offset",
+			script: `
+				const b = Buffer.from([0x12, 0x34, 0x56]);
+				if (b.readUInt16BE(1).toString(16) !== "3456") {
+					throw new Error(b);
+				}
+			`,
+		},
+		{
+			name: "with no/default offset",
+			script: `
+				const b = Buffer.from([0x12, 0x34, 0x56]);
+				if (b.readUInt16BE().toString(16) !== "1234") {
+					throw new Error(b);
+				}
+			`,
+		},
+	}
+
+	runTestCases(t, tcs)
+}
+
+func TestBuffer_readUInt16LE(t *testing.T) {
+	tcs := []testCase{
+		{
+			name: "with zero offset",
+			script: `
+				const b = Buffer.from([0x12, 0x34, 0x56]);
+				if (b.readUInt16LE(0).toString(16) !== "3412") {
+					throw new Error(b);
+				}
+			`,
+		},
+		{
+			name: "with last offset",
+			script: `
+				const b = Buffer.from([0x12, 0x34, 0x56]);
+				if (b.readUInt16LE(1).toString(16) !== "5634") {
+					throw new Error(b);
+				}
+			`,
+		},
+		{
+			name: "out of range offset",
+			script: `
+				const b = Buffer.from([0x12, 0x34, 0x56]);
+				// this should error
+				b.readUInt16LE(2);	
+				throw new Error("should not get here");
+			`,
+			expectedErr: `Error [ERR_OUT_OF_RANGE]: The value of "offset" 2 is out of range`,
+		},
+	}
+
+	runTestCases(t, tcs)
+}
+
+func TestBuffer_readUInt32BE(t *testing.T) {
+	tcs := []testCase{
+		{
+			name: "with zero offset",
+			script: `
+				const b = Buffer.from([0x12, 0x34, 0x56, 0x78]);
+				if (b.readUInt32BE(0).toString(16) !== "12345678") {
+					throw new Error(b);
+				}
+			`,
+		},
+		{
+			name: "with no/default offset",
+			script: `
+				const b = Buffer.from([0x12, 0x34, 0x56, 0x78]);
+				if (b.readUInt32BE().toString(16) !== "12345678") {
+					throw new Error(b);
+				}
+			`,
+		},
+	}
+
+	runTestCases(t, tcs)
+}
+
+func TestBuffer_readUInt32LE(t *testing.T) {
+	tcs := []testCase{
+		{
+			name: "with zero offset",
+			script: `
+				const b = Buffer.from([0x12, 0x34, 0x56, 0x78]);
+				if (b.readUInt32LE(0).toString(16) !== "78563412") {
+					throw new Error(b);
+				}
+			`,
+		},
+		{
+			name: "with no/default offset",
+			script: `
+				const b = Buffer.from([0x12, 0x34, 0x56, 0x78]);
+				if (b.readUInt32LE().toString(16) !== "78563412") {
+					throw new Error(b);
+				}
+			`,
+		},
+		{
+			name: "with string offset",
+			script: `
+				const b = Buffer.from([0x12, 0x34, 0x56, 0x78]);
+				// this should error
+				b.readUInt32LE("foo"); 
+				throw new Error("should not get here");// this should error
+			`,
+			expectedErr: `TypeError [ERR_INVALID_ARG_TYPE]: The "offset" argument must be of type number`,
+		},
+		{
+			name: "with negative offset",
+			script: `
+				const b = Buffer.from([0x12, 0x34, 0x56, 0x78]);
+				// this should error
+				b.readUInt32LE(-1);
+				throw new Error("should not get here");// this should error
+			`,
+			expectedErr: `Error [ERR_OUT_OF_RANGE]: The value of "offset" -1 is out of range`,
+		},
+	}
+
+	runTestCases(t, tcs)
 }

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -11,6 +11,7 @@ const (
 	ErrCodeInvalidArgValue = "ERR_INVALID_ARG_VALUE"
 	ErrCodeInvalidThis     = "ERR_INVALID_THIS"
 	ErrCodeMissingArgs     = "ERR_MISSING_ARGS"
+	ErrCodedOutOfRange     = "ERR_OUT_OF_RANGE"
 )
 
 func error_toString(call goja.FunctionCall, r *goja.Runtime) goja.Value {

--- a/go.mod
+++ b/go.mod
@@ -4,14 +4,14 @@ go 1.20
 
 require (
 	github.com/dop251/base64dec v0.0.0-20231022112746-c6c9f9a96217
-	github.com/dop251/goja v0.0.0-20240707163329-b1681fb2a2f5
+	github.com/dop251/goja v0.0.0-20250125213203-5ef83b82af17
 	go.uber.org/goleak v1.3.0
 	golang.org/x/net v0.27.0
 	golang.org/x/text v0.16.0
 )
 
 require (
-	github.com/dlclark/regexp2 v1.11.2 // indirect
+	github.com/dlclark/regexp2 v1.11.4 // indirect
 	github.com/go-sourcemap/sourcemap v2.1.4+incompatible // indirect
 	github.com/google/pprof v0.0.0-20240727154555-813a5fbdbec8 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,10 +1,14 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/dlclark/regexp2 v1.11.2 h1:/u628IuisSTwri5/UKloiIsH8+qF2Pu7xEQX+yIKg68=
 github.com/dlclark/regexp2 v1.11.2/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
+github.com/dlclark/regexp2 v1.11.4 h1:rPYF9/LECdNymJufQKmri9gV604RvvABwgOA8un7yAo=
+github.com/dlclark/regexp2 v1.11.4/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/dop251/base64dec v0.0.0-20231022112746-c6c9f9a96217 h1:16iT9CBDOniJwFGPI41MbUDfEk74hFaKTqudrX8kenY=
 github.com/dop251/base64dec v0.0.0-20231022112746-c6c9f9a96217/go.mod h1:eIb+f24U+eWQCIsj9D/ah+MD9UP+wdxuqzsdLD+mhGM=
 github.com/dop251/goja v0.0.0-20240707163329-b1681fb2a2f5 h1:ZRqTaoW9WZ2DqeOQGhK9q73eCb47SEs30GV2IRHT9bo=
 github.com/dop251/goja v0.0.0-20240707163329-b1681fb2a2f5/go.mod h1:o31y53rb/qiIAONF7w3FHJZRqqP3fzHUr1HqanthByw=
+github.com/dop251/goja v0.0.0-20250125213203-5ef83b82af17 h1:spJaibPy2sZNwo6Q0HjBVufq7hBUj5jNFOKRoogCBow=
+github.com/dop251/goja v0.0.0-20250125213203-5ef83b82af17/go.mod h1:MxLav0peU43GgvwVgNbLAj1s/bSGboKkhuULvq/7hx4=
 github.com/go-sourcemap/sourcemap v2.1.4+incompatible h1:a+iTbH5auLKxaNwQFg0B+TCYl6lbukKPc7b5x0n1s6Q=
 github.com/go-sourcemap/sourcemap v2.1.4+incompatible/go.mod h1:F8jJfvm2KbVjc5NqelyYJmf/v5J0dwNLS2mL4sNA1Jg=
 github.com/google/pprof v0.0.0-20240727154555-813a5fbdbec8 h1:FKHo8hFI3A+7w0aUQuYXQ+6EN5stWmeY/AZqtM8xk9k=


### PR DESCRIPTION
- added all the fixed size `Buffer.read` methods. Note that the data for the unit tests came from the Node JS [API examples](https://nodejs.org/api/buffer.htm). Will add the variable sized reads next.
- also upgraded `goja` to get `BigInt` support