### PR TITLE
Added variable length `Buffer.read*` methods

### DIFF
--- a/buffer/buffer.go
+++ b/buffer/buffer.go
@@ -681,7 +681,7 @@ func (b *Buffer) newArgumentNotNumberTypeError(name string) *goja.Object {
 }
 
 func (b *Buffer) newArgumentOutOfRangeError(name string, v int64) *goja.Object {
-	return errors.NewError(b.r, nil, errors.ErrCodedOutOfRange, "The value of \"%s\" %d is out of range", name, v)
+	return errors.NewRangeError(b.r, errors.ErrCodeOutOfRange, "The value of \"%s\" %d is out of range", name, v)
 }
 
 func Require(runtime *goja.Runtime, module *goja.Object) {

--- a/buffer/buffer.go
+++ b/buffer/buffer.go
@@ -524,6 +524,36 @@ func (b *Buffer) readInt32LE(call goja.FunctionCall) goja.Value {
 	return b.r.ToValue(value)
 }
 
+// readIntBE reads a big-endian signed integer of variable byte length
+func (b *Buffer) readIntBE(call goja.FunctionCall) goja.Value {
+	bb := Bytes(b.r, call.This)
+	offset, byteLength := b.getVariableLengthReadArguments(call, bb)
+
+	var value int64
+	for i := int64(0); i < byteLength; i++ {
+		value = (value << 8) | int64(bb[offset+i])
+	}
+
+	value = signExtend(value, byteLength)
+
+	return b.r.ToValue(value)
+}
+
+// readIntLE reads a little-endian signed integer of variable byte length
+func (b *Buffer) readIntLE(call goja.FunctionCall) goja.Value {
+	bb := Bytes(b.r, call.This)
+	offset, byteLength := b.getVariableLengthReadArguments(call, bb)
+
+	var value int64
+	for i := byteLength - 1; i >= 0; i-- {
+		value = (value << 8) | int64(bb[offset+i])
+	}
+
+	value = signExtend(value, byteLength)
+
+	return b.r.ToValue(value)
+}
+
 // readUInt8 reads an 8-bit unsigned integer from the buffer
 func (b *Buffer) readUInt8(call goja.FunctionCall) goja.Value {
 	bb := Bytes(b.r, call.This)
@@ -569,6 +599,32 @@ func (b *Buffer) readUInt32LE(call goja.FunctionCall) goja.Value {
 	return b.r.ToValue(value)
 }
 
+// readUIntBE reads a big-endian unsigned integer of variable byte length
+func (b *Buffer) readUIntBE(call goja.FunctionCall) goja.Value {
+	bb := Bytes(b.r, call.This)
+	offset, byteLength := b.getVariableLengthReadArguments(call, bb)
+
+	var value uint64
+	for i := int64(0); i < byteLength; i++ {
+		value = (value << 8) | uint64(bb[offset+i])
+	}
+
+	return b.r.ToValue(value)
+}
+
+// readUIntLE reads a little-endian unsigned integer of variable byte length
+func (b *Buffer) readUIntLE(call goja.FunctionCall) goja.Value {
+	bb := Bytes(b.r, call.This)
+	offset, byteLength := b.getVariableLengthReadArguments(call, bb)
+
+	var value uint64
+	for i := byteLength - 1; i >= 0; i-- {
+		value = (value << 8) | uint64(bb[offset+i])
+	}
+
+	return b.r.ToValue(value)
+}
+
 func (b *Buffer) getOffsetArgument(call goja.FunctionCall, argIndex int, bb []byte, numBytes int64) int64 {
 	arg := call.Argument(argIndex)
 	var offset int64
@@ -578,14 +634,54 @@ func (b *Buffer) getOffsetArgument(call goja.FunctionCall, argIndex int, bb []by
 		// optional arg that defaults to zero
 		offset = 0
 	} else {
-		panic(errors.NewTypeError(b.r, errors.ErrCodeInvalidArgType, "The \"offset\" argument must be of type number."))
+		panic(b.newArgumentNotNumberTypeError("offset"))
 	}
 
 	if offset < 0 || offset+numBytes > int64(len(bb)) {
-		panic(errors.NewError(b.r, nil, errors.ErrCodedOutOfRange, "The value of \"offset\" %d is out of range", offset))
+		panic(b.newArgumentOutOfRangeError("offset", offset))
 	}
 
 	return offset
+}
+
+func (b *Buffer) getVariableLengthReadArguments(call goja.FunctionCall, bb []byte) (int64, int64) {
+	offset := b.getRequiredIntegerArgument(call, "offset", 0)
+	byteLength := b.getRequiredIntegerArgument(call, "byteLength", 1)
+
+	if byteLength < 1 || byteLength > 6 {
+		panic(b.newArgumentOutOfRangeError("byteLength", byteLength))
+	}
+	if offset < 0 || offset+byteLength > int64(len(bb)) {
+		panic(b.newArgumentOutOfRangeError("offset", offset))
+	}
+
+	return offset, byteLength
+}
+
+func signExtend(value int64, numBytes int64) int64 {
+	// we don't have to turn this to a uint64 first because numBytes < 8 so
+	// the sign bit will never pushed out of the int64 range
+	return (value << (64 - 8*numBytes)) >> (64 - 8*numBytes)
+}
+
+func (b *Buffer) getRequiredIntegerArgument(call goja.FunctionCall, name string, argIndex int) int64 {
+	arg := call.Argument(argIndex)
+	if isNumber(arg) {
+		return arg.ToInteger()
+	}
+	if goja.IsUndefined(arg) {
+		panic(errors.NewTypeError(b.r, errors.ErrCodeInvalidArgType, "The \"%s\" argument is required.", name))
+	}
+
+	panic(b.newArgumentNotNumberTypeError(name))
+}
+
+func (b *Buffer) newArgumentNotNumberTypeError(name string) *goja.Object {
+	return errors.NewTypeError(b.r, errors.ErrCodeInvalidArgType, "The \"%s\" argument must be of type number.", name)
+}
+
+func (b *Buffer) newArgumentOutOfRangeError(name string, v int64) *goja.Object {
+	return errors.NewError(b.r, nil, errors.ErrCodedOutOfRange, "The value of \"%s\" %d is out of range", name, v)
 }
 
 func Require(runtime *goja.Runtime, module *goja.Object) {
@@ -622,11 +718,15 @@ func Require(runtime *goja.Runtime, module *goja.Object) {
 	proto.Set("readInt16LE", b.readInt16LE)
 	proto.Set("readInt32BE", b.readInt32BE)
 	proto.Set("readInt32LE", b.readInt32LE)
+	proto.Set("readIntBE", b.readIntBE)
+	proto.Set("readIntLE", b.readIntLE)
 	proto.Set("readUInt8", b.readUInt8)
 	proto.Set("readUInt16BE", b.readUInt16BE)
 	proto.Set("readUInt16LE", b.readUInt16LE)
 	proto.Set("readUInt32BE", b.readUInt32BE)
 	proto.Set("readUInt32LE", b.readUInt32LE)
+	proto.Set("readUIntBE", b.readUIntBE)
+	proto.Set("readUIntLE", b.readUIntLE)
 
 	ctor.Set("prototype", proto)
 	ctor.Set("poolSize", 8192)

--- a/buffer/buffer.go
+++ b/buffer/buffer.go
@@ -708,7 +708,13 @@ func Require(runtime *goja.Runtime, module *goja.Object) {
 	proto.Set("readBigInt64BE", b.readBigInt64BE)
 	proto.Set("readBigInt64LE", b.readBigInt64LE)
 	proto.Set("readBigUInt64BE", b.readBigUInt64BE)
+	// aliases for readBigUInt64BE
+	proto.Set("readBigUint64BE", b.readBigUInt64BE)
+
 	proto.Set("readBigUInt64LE", b.readBigUInt64LE)
+	// aliases for readBigUInt64LE
+	proto.Set("readBigUint64LE", b.readBigUInt64LE)
+
 	proto.Set("readDoubleBE", b.readDoubleBE)
 	proto.Set("readDoubleLE", b.readDoubleLE)
 	proto.Set("readFloatBE", b.readFloatBE)
@@ -721,12 +727,32 @@ func Require(runtime *goja.Runtime, module *goja.Object) {
 	proto.Set("readIntBE", b.readIntBE)
 	proto.Set("readIntLE", b.readIntLE)
 	proto.Set("readUInt8", b.readUInt8)
+	// aliases for readUInt8
+	proto.Set("readUint8", b.readUInt8)
+
 	proto.Set("readUInt16BE", b.readUInt16BE)
+	// aliases for readUInt16BE
+	proto.Set("readUint16BE", b.readUInt16BE)
+
 	proto.Set("readUInt16LE", b.readUInt16LE)
+	// aliases for readUInt16LE
+	proto.Set("readUint16LE", b.readUInt16LE)
+
 	proto.Set("readUInt32BE", b.readUInt32BE)
+	// aliases for readUInt32BE
+	proto.Set("readUint32BE", b.readUInt32BE)
+
 	proto.Set("readUInt32LE", b.readUInt32LE)
+	// aliases for readUInt32LE
+	proto.Set("readUint32LE", b.readUInt32LE)
+
 	proto.Set("readUIntBE", b.readUIntBE)
+	// aliases for readUIntBE
+	proto.Set("readUintBE", b.readUIntBE)
+
 	proto.Set("readUIntLE", b.readUIntLE)
+	// aliases for readUIntLE
+	proto.Set("readUintLE", b.readUIntLE)
 
 	ctor.Set("prototype", proto)
 	ctor.Set("poolSize", 8192)

--- a/buffer/buffer_test.go
+++ b/buffer/buffer_test.go
@@ -339,6 +339,15 @@ func TestBuffer_readBigUInt64BE(t *testing.T) {
 				}
 			`,
 		},
+		{
+			name: "use alias",
+			script: `
+				const b = Buffer.from([0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff]);
+				if (b.readBigUint64BE() !== BigInt(4294967295)) {
+					throw new Error(b);
+				}
+			`,
+		},
 	}
 
 	runTestCases(t, tcs)
@@ -364,6 +373,15 @@ func TestBuffer_readBigUInt64LE(t *testing.T) {
 				throw new Error("should not get here");
 			`,
 			expectedErr: `RangeError [ERR_OUT_OF_RANGE]: The value of "offset" 1 is out of range`,
+		},
+		{
+			name: "use alias",
+			script: `
+				const b = Buffer.from([0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff]);
+				if (b.readBigUint64LE(0) !== BigInt(18446744069414584320)) {
+					throw new Error(b);
+				}
+			`,
 		},
 	}
 
@@ -810,6 +828,15 @@ func TestBuffer_readUInt8(t *testing.T) {
 				}
 			`,
 		},
+		{
+			name: "use alias",
+			script: `
+				const b = Buffer.from([1, -2]);
+				if (b.readUint8() !== 1) {
+					throw new Error(b);
+				}
+			`,
+		},
 	}
 
 	runTestCases(t, tcs)
@@ -840,6 +867,15 @@ func TestBuffer_readUInt16BE(t *testing.T) {
 			script: `
 				const b = Buffer.from([0x12, 0x34, 0x56]);
 				if (b.readUInt16BE().toString(16) !== "1234") {
+					throw new Error(b);
+				}
+			`,
+		},
+		{
+			name: "use alias",
+			script: `
+				const b = Buffer.from([0x12, 0x34, 0x56]);
+				if (b.readUint16BE().toString(16) !== "1234") {
 					throw new Error(b);
 				}
 			`,
@@ -879,6 +915,15 @@ func TestBuffer_readUInt16LE(t *testing.T) {
 			`,
 			expectedErr: `RangeError [ERR_OUT_OF_RANGE]: The value of "offset" 2 is out of range`,
 		},
+		{
+			name: "use alias",
+			script: `
+				const b = Buffer.from([0x12, 0x34, 0x56]);
+				if (b.readUint16LE(1).toString(16) !== "5634") {
+					throw new Error(b);
+				}
+			`,
+		},
 	}
 
 	runTestCases(t, tcs)
@@ -900,6 +945,15 @@ func TestBuffer_readUInt32BE(t *testing.T) {
 			script: `
 				const b = Buffer.from([0x12, 0x34, 0x56, 0x78]);
 				if (b.readUInt32BE().toString(16) !== "12345678") {
+					throw new Error(b);
+				}
+			`,
+		},
+		{
+			name: "use alias",
+			script: `
+				const b = Buffer.from([0x12, 0x34, 0x56, 0x78]);
+				if (b.readUint32BE(0).toString(16) !== "12345678") {
 					throw new Error(b);
 				}
 			`,
@@ -948,6 +1002,15 @@ func TestBuffer_readUInt32LE(t *testing.T) {
 				throw new Error("should not get here");// this should error
 			`,
 			expectedErr: `RangeError [ERR_OUT_OF_RANGE]: The value of "offset" -1 is out of range`,
+		},
+		{
+			name: "use alias",
+			script: `
+				const b = Buffer.from([0x12, 0x34, 0x56, 0x78]);
+				if (b.readUint32LE(0).toString(16) !== "78563412") {
+					throw new Error(b);
+				}
+			`,
 		},
 	}
 
@@ -1004,6 +1067,15 @@ func TestBuffer_readUIntBE(t *testing.T) {
 			`,
 			expectedErr: `RangeError [ERR_OUT_OF_RANGE]: The value of "offset" 4 is out of range`,
 		},
+		{
+			name: "use alias",
+			script: `
+				const b = Buffer.from([0x12, 0x34, 0x56, 0x78, 0x90, 0xab]);
+				if (b.readUintBE(1, 1) !== 52) {
+					throw new Error(b);
+				}
+			`,
+		},
 	}
 
 	runTestCases(t, tcs)
@@ -1058,6 +1130,15 @@ func TestBuffer_readUIntLE(t *testing.T) {
 				throw new Error("should not get here");
 			`,
 			expectedErr: `RangeError [ERR_OUT_OF_RANGE]: The value of "offset" 4 is out of range`,
+		},
+		{
+			name: "use alias",
+			script: `
+				const b = Buffer.from([0x12, 0x34, 0x56, 0x78, 0x90, 0xab]);
+				if (b.readUintLE(1, 1) !== 52) {
+					throw new Error(b);
+				}
+			`,
 		},
 	}
 

--- a/buffer/buffer_test.go
+++ b/buffer/buffer_test.go
@@ -637,6 +637,150 @@ func TestBuffer_readInt32LE(t *testing.T) {
 	runTestCases(t, tcs)
 }
 
+func TestName(t *testing.T) {
+
+}
+
+func TestBuffer_readIntBE(t *testing.T) {
+	tcs := []testCase{
+		{
+			name: "6 byte positive integer",
+			script: `
+				const b = Buffer.from([0x12, 0x34, 0x56, 0x78, 0x90, 0xab]);
+				if (b.readIntBE(0, 6) !== 20015998341291) {
+					throw new Error(b);
+				}
+			`,
+		},
+		{
+			name: "1 byte negative integer",
+			script: `
+				const b = Buffer.from([0x12, 0x34, 0x56, 0x78, 0x90, 0xab]);
+				if (b.readIntBE(4, 1) !== -112) {
+					throw new Error(b);
+				}
+			`,
+		},
+		{
+			name: "with no parameters",
+			script: `
+				const b = Buffer.from([0x12, 0x34, 0x56, 0x78, 0x90, 0xab]);
+				// this should error 
+				b.readIntBE();
+				throw new Error("should not get here");
+			`,
+			expectedErr: `TypeError [ERR_INVALID_ARG_TYPE]: The "offset" argument is required`,
+		},
+		{
+			name: "type mismatch for offset",
+			script: `
+				const b = Buffer.from([0x12, 0x34, 0x56, 0x78, 0x90, 0xab]);
+				// this should error 
+				b.readIntBE("1");
+				throw new Error("should not get here");
+			`,
+			expectedErr: `TypeError [ERR_INVALID_ARG_TYPE]: The "offset" argument must be of type number`,
+		},
+		{
+			name: "with no byteLength parameter",
+			script: `
+				const b = Buffer.from([0x12, 0x34, 0x56, 0x78, 0x90, 0xab]);
+				// this should error 
+				b.readIntBE(0);
+				throw new Error("should not get here");
+			`,
+			expectedErr: `TypeError [ERR_INVALID_ARG_TYPE]: The "byteLength" argument is required`,
+		},
+		{
+			name: "byteLength less than 1",
+			script: `
+				const b = Buffer.from([0x12, 0x34, 0x56, 0x78, 0x90, 0xab]);
+				// this should error 
+				b.readIntBE(0,0);
+				throw new Error("should not get here");
+			`,
+			expectedErr: `Error [ERR_OUT_OF_RANGE]: The value of "byteLength" 0 is out of range`,
+		},
+		{
+			name: "byteLength greater than 7",
+			script: `
+				const b = Buffer.from([0x12, 0x34, 0x56, 0x78, 0x90, 0xab]);
+				// this should error 
+				b.readIntBE(0,7);
+				throw new Error("should not get here");
+			`,
+			expectedErr: `Error [ERR_OUT_OF_RANGE]: The value of "byteLength" 7 is out of range`,
+		},
+		{
+			name: "offset plus byteLength out of range",
+			script: `
+				const b = Buffer.from([0x12, 0x34, 0x56, 0x78, 0x90, 0xab]);
+				// this should error 
+				b.readIntBE(4,3);
+				throw new Error("should not get here");
+			`,
+			expectedErr: `Error [ERR_OUT_OF_RANGE]: The value of "offset" 4 is out of range`,
+		},
+	}
+
+	runTestCases(t, tcs)
+}
+
+func TestBuffer_readIntLE(t *testing.T) {
+	tcs := []testCase{
+		{
+			name: "6 byte negative integer",
+			script: `
+				const b = Buffer.from([0x12, 0x34, 0x56, 0x78, 0x90, 0xab]);
+				if (b.readIntLE(0, 6) !== -92837994154990) {
+					throw new Error(b);
+				}
+			`,
+		},
+		{
+			name: "1 byte positive integer",
+			script: `
+				const b = Buffer.from([0x12, 0x34, 0x56, 0x78, 0x90, 0xab]);
+				if (b.readIntLE(0, 1) !== 18) {
+					throw new Error(b);
+				}
+			`,
+		},
+		{
+			name: "with no parameters",
+			script: `
+				const b = Buffer.from([0x12, 0x34, 0x56, 0x78, 0x90, 0xab]);
+				// this should error 
+				b.readIntLE();
+				throw new Error("should not get here");
+			`,
+			expectedErr: `TypeError [ERR_INVALID_ARG_TYPE]: The "offset" argument is required`,
+		},
+		{
+			name: "with no byteLength parameter",
+			script: `
+				const b = Buffer.from([0x12, 0x34, 0x56, 0x78, 0x90, 0xab]);
+				// this should error 
+				b.readIntLE(0);
+				throw new Error("should not get here");
+			`,
+			expectedErr: `TypeError [ERR_INVALID_ARG_TYPE]: The "byteLength" argument is required`,
+		},
+		{
+			name: "offset plus byteLength out of range",
+			script: `
+				const b = Buffer.from([0x12, 0x34, 0x56, 0x78, 0x90, 0xab]);
+				// this should error 
+				b.readIntLE(4,3);
+				throw new Error("should not get here");
+			`,
+			expectedErr: `Error [ERR_OUT_OF_RANGE]: The value of "offset" 4 is out of range`,
+		},
+	}
+
+	runTestCases(t, tcs)
+}
+
 func TestBuffer_readUInt8(t *testing.T) {
 	tcs := []testCase{
 		{
@@ -804,6 +948,116 @@ func TestBuffer_readUInt32LE(t *testing.T) {
 				throw new Error("should not get here");// this should error
 			`,
 			expectedErr: `Error [ERR_OUT_OF_RANGE]: The value of "offset" -1 is out of range`,
+		},
+	}
+
+	runTestCases(t, tcs)
+}
+
+func TestBuffer_readUIntBE(t *testing.T) {
+	tcs := []testCase{
+		{
+			name: "6 byte integer",
+			script: `
+				const b = Buffer.from([0x12, 0x34, 0x56, 0x78, 0x90, 0xab]);
+				if (b.readUIntBE(0, 6) !== 20015998341291) {
+					throw new Error(b);
+				}
+			`,
+		},
+		{
+			name: "1 byte integer",
+			script: `
+				const b = Buffer.from([0x12, 0x34, 0x56, 0x78, 0x90, 0xab]);
+				if (b.readUIntBE(1, 1) !== 52) {
+					throw new Error(b);
+				}
+			`,
+		},
+		{
+			name: "with no parameters",
+			script: `
+				const b = Buffer.from([0x12, 0x34, 0x56, 0x78, 0x90, 0xab]);
+				// this should error 
+				b.readUIntBE();
+				throw new Error("should not get here");
+			`,
+			expectedErr: `TypeError [ERR_INVALID_ARG_TYPE]: The "offset" argument is required`,
+		},
+		{
+			name: "with no byteLength parameter",
+			script: `
+				const b = Buffer.from([0x12, 0x34, 0x56, 0x78, 0x90, 0xab]);
+				// this should error 
+				b.readUIntBE(0);
+				throw new Error("should not get here");
+			`,
+			expectedErr: `TypeError [ERR_INVALID_ARG_TYPE]: The "byteLength" argument is required`,
+		},
+		{
+			name: "offset plus byteLength out of range",
+			script: `
+				const b = Buffer.from([0x12, 0x34, 0x56, 0x78, 0x90, 0xab]);
+				// this should error 
+				b.readUIntBE(4,3);
+				throw new Error("should not get here");
+			`,
+			expectedErr: `Error [ERR_OUT_OF_RANGE]: The value of "offset" 4 is out of range`,
+		},
+	}
+
+	runTestCases(t, tcs)
+}
+
+func TestBuffer_readUIntLE(t *testing.T) {
+	tcs := []testCase{
+		{
+			name: "6 byte integer",
+			script: `
+				const b = Buffer.from([0x12, 0x34, 0x56, 0x78, 0x90, 0xab]);
+				if (b.readUIntLE(0, 6) !== 188636982555666) {
+					throw new Error(b);
+				}
+			`,
+		},
+		{
+			name: "1 byte integer",
+			script: `
+				const b = Buffer.from([0x12, 0x34, 0x56, 0x78, 0x90, 0xab]);
+				if (b.readUIntLE(1, 1) !== 52) {
+					throw new Error(b);
+				}
+			`,
+		},
+		{
+			name: "with no parameters",
+			script: `
+				const b = Buffer.from([0x12, 0x34, 0x56, 0x78, 0x90, 0xab]);
+				// this should error 
+				b.readUIntLE();
+				throw new Error("should not get here");
+			`,
+			expectedErr: `TypeError [ERR_INVALID_ARG_TYPE]: The "offset" argument is required`,
+		},
+		{
+			name: "with no byteLength parameter",
+			script: `
+				const b = Buffer.from([0x12, 0x34, 0x56, 0x78, 0x90, 0xab]);
+				// this should error 
+				b.readUIntLE(0);
+				throw new Error("should not get here");
+			`,
+			expectedErr: `TypeError [ERR_INVALID_ARG_TYPE]: The "byteLength" argument is required`,
+		},
+		{
+			name: "offset plus byteLength out of range",
+			script: `
+				const b = Buffer.from([0x12, 0x34, 0x56, 0x78, 0x90, 0xab]);
+				// this should error 
+				b.readUIntLE(4,3);
+				throw new Error("should not get here");
+			`,
+			expectedErr: `Error [ERR_OUT_OF_RANGE]: The value of "offset" 4 is out of range`,
 		},
 	}
 

--- a/buffer/buffer_test.go
+++ b/buffer/buffer_test.go
@@ -312,7 +312,7 @@ func TestBuffer_readBigInt64LE(t *testing.T) {
 				b.readBigInt64LE(1);
 				throw new Error("should not get here");
 			`,
-			expectedErr: `Error [ERR_OUT_OF_RANGE]: The value of "offset" 1 is out of range`,
+			expectedErr: `RangeError [ERR_OUT_OF_RANGE]: The value of "offset" 1 is out of range`,
 		},
 	}
 
@@ -363,7 +363,7 @@ func TestBuffer_readBigUInt64LE(t *testing.T) {
 				b.readBigUInt64LE(1);
 				throw new Error("should not get here");
 			`,
-			expectedErr: `Error [ERR_OUT_OF_RANGE]: The value of "offset" 1 is out of range`,
+			expectedErr: `RangeError [ERR_OUT_OF_RANGE]: The value of "offset" 1 is out of range`,
 		},
 	}
 
@@ -414,7 +414,7 @@ func TestBuffer_readDoubleLE(t *testing.T) {
 				b.readDoubleLE(1);
 				throw new Error("should not get here");
 			`,
-			expectedErr: `Error [ERR_OUT_OF_RANGE]: The value of "offset" 1 is out of range`,
+			expectedErr: `RangeError [ERR_OUT_OF_RANGE]: The value of "offset" 1 is out of range`,
 		},
 	}
 
@@ -465,7 +465,7 @@ func TestBuffer_readFloatLE(t *testing.T) {
 				b.readFloatLE(1);
 				throw new Error("should not get here");
 			`,
-			expectedErr: `Error [ERR_OUT_OF_RANGE]: The value of "offset" 1 is out of range`,
+			expectedErr: `RangeError [ERR_OUT_OF_RANGE]: The value of "offset" 1 is out of range`,
 		},
 	}
 
@@ -525,7 +525,7 @@ func TestBuffer_readInt16BE(t *testing.T) {
 				b.readInt16BE(1);
 				throw new Error("should not get here");
 			`,
-			expectedErr: `Error [ERR_OUT_OF_RANGE]: The value of "offset" 1 is out of range`,
+			expectedErr: `RangeError [ERR_OUT_OF_RANGE]: The value of "offset" 1 is out of range`,
 		},
 		{
 			name: "with no/default offset",
@@ -560,7 +560,7 @@ func TestBuffer_readInt16LE(t *testing.T) {
 				b.readInt16LE(1);
 				throw new Error("should not get here");
 			`,
-			expectedErr: `Error [ERR_OUT_OF_RANGE]: The value of "offset" 1 is out of range`,
+			expectedErr: `RangeError [ERR_OUT_OF_RANGE]: The value of "offset" 1 is out of range`,
 		},
 	}
 
@@ -586,7 +586,7 @@ func TestBuffer_readInt32BE(t *testing.T) {
 				b.readInt32BE(1);
 				throw new Error("should not get here");
 			`,
-			expectedErr: `Error [ERR_OUT_OF_RANGE]: The value of "offset" 1 is out of range`,
+			expectedErr: `RangeError [ERR_OUT_OF_RANGE]: The value of "offset" 1 is out of range`,
 		},
 		{
 			name: "with no/default offset",
@@ -621,7 +621,7 @@ func TestBuffer_readInt32LE(t *testing.T) {
 				b.readInt32LE(1);
 				throw new Error("should not get here");
 			`,
-			expectedErr: `Error [ERR_OUT_OF_RANGE]: The value of "offset" 1 is out of range`,
+			expectedErr: `RangeError [ERR_OUT_OF_RANGE]: The value of "offset" 1 is out of range`,
 		},
 		{
 			name: "with no/default offset",
@@ -699,7 +699,7 @@ func TestBuffer_readIntBE(t *testing.T) {
 				b.readIntBE(0,0);
 				throw new Error("should not get here");
 			`,
-			expectedErr: `Error [ERR_OUT_OF_RANGE]: The value of "byteLength" 0 is out of range`,
+			expectedErr: `RangeError [ERR_OUT_OF_RANGE]: The value of "byteLength" 0 is out of range`,
 		},
 		{
 			name: "byteLength greater than 7",
@@ -709,7 +709,7 @@ func TestBuffer_readIntBE(t *testing.T) {
 				b.readIntBE(0,7);
 				throw new Error("should not get here");
 			`,
-			expectedErr: `Error [ERR_OUT_OF_RANGE]: The value of "byteLength" 7 is out of range`,
+			expectedErr: `RangeError [ERR_OUT_OF_RANGE]: The value of "byteLength" 7 is out of range`,
 		},
 		{
 			name: "offset plus byteLength out of range",
@@ -719,7 +719,7 @@ func TestBuffer_readIntBE(t *testing.T) {
 				b.readIntBE(4,3);
 				throw new Error("should not get here");
 			`,
-			expectedErr: `Error [ERR_OUT_OF_RANGE]: The value of "offset" 4 is out of range`,
+			expectedErr: `RangeError [ERR_OUT_OF_RANGE]: The value of "offset" 4 is out of range`,
 		},
 	}
 
@@ -774,7 +774,7 @@ func TestBuffer_readIntLE(t *testing.T) {
 				b.readIntLE(4,3);
 				throw new Error("should not get here");
 			`,
-			expectedErr: `Error [ERR_OUT_OF_RANGE]: The value of "offset" 4 is out of range`,
+			expectedErr: `RangeError [ERR_OUT_OF_RANGE]: The value of "offset" 4 is out of range`,
 		},
 	}
 
@@ -877,7 +877,7 @@ func TestBuffer_readUInt16LE(t *testing.T) {
 				b.readUInt16LE(2);	
 				throw new Error("should not get here");
 			`,
-			expectedErr: `Error [ERR_OUT_OF_RANGE]: The value of "offset" 2 is out of range`,
+			expectedErr: `RangeError [ERR_OUT_OF_RANGE]: The value of "offset" 2 is out of range`,
 		},
 	}
 
@@ -947,7 +947,7 @@ func TestBuffer_readUInt32LE(t *testing.T) {
 				b.readUInt32LE(-1);
 				throw new Error("should not get here");// this should error
 			`,
-			expectedErr: `Error [ERR_OUT_OF_RANGE]: The value of "offset" -1 is out of range`,
+			expectedErr: `RangeError [ERR_OUT_OF_RANGE]: The value of "offset" -1 is out of range`,
 		},
 	}
 
@@ -1002,7 +1002,7 @@ func TestBuffer_readUIntBE(t *testing.T) {
 				b.readUIntBE(4,3);
 				throw new Error("should not get here");
 			`,
-			expectedErr: `Error [ERR_OUT_OF_RANGE]: The value of "offset" 4 is out of range`,
+			expectedErr: `RangeError [ERR_OUT_OF_RANGE]: The value of "offset" 4 is out of range`,
 		},
 	}
 
@@ -1057,7 +1057,7 @@ func TestBuffer_readUIntLE(t *testing.T) {
 				b.readUIntLE(4,3);
 				throw new Error("should not get here");
 			`,
-			expectedErr: `Error [ERR_OUT_OF_RANGE]: The value of "offset" 4 is out of range`,
+			expectedErr: `RangeError [ERR_OUT_OF_RANGE]: The value of "offset" 4 is out of range`,
 		},
 	}
 

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -11,7 +11,7 @@ const (
 	ErrCodeInvalidArgValue = "ERR_INVALID_ARG_VALUE"
 	ErrCodeInvalidThis     = "ERR_INVALID_THIS"
 	ErrCodeMissingArgs     = "ERR_MISSING_ARGS"
-	ErrCodedOutOfRange     = "ERR_OUT_OF_RANGE"
+	ErrCodeOutOfRange      = "ERR_OUT_OF_RANGE"
 )
 
 func error_toString(call goja.FunctionCall, r *goja.Runtime) goja.Value {
@@ -49,6 +49,11 @@ func NewTypeError(r *goja.Runtime, code string, params ...interface{}) *goja.Obj
 	e := r.NewTypeError(params...)
 	addProps(r, e, code)
 	return e
+}
+
+func NewRangeError(r *goja.Runtime, code string, params ...interface{}) *goja.Object {
+	ctor, _ := r.Get("RangeError").(*goja.Object)
+	return NewError(r, ctor, code, params...)
 }
 
 func NewError(r *goja.Runtime, ctor *goja.Object, code string, args ...interface{}) *goja.Object {


### PR DESCRIPTION
Added variable length `Buffer.read*` methods
- added `readIntBE`, `readIntLE`, `readUIntBE`, and `readUIntLE`.
- also refactored out some common methods to create errors