### PR TITLE
Fix: in require(), use os.Getwd() when frames[1].SrcName() is empty

### DIFF
--- a/require/module_test.go
+++ b/require/module_test.go
@@ -365,6 +365,7 @@ func TestResolve(t *testing.T) {
 		"/node_modules/b/file.js":                `exports.name = "app13"`,
 		"node_modules/app14/index.js":            `exports.name = "app14"`,
 		"../node_modules/app15/index.js":         `exports.name = "app15"`,
+		"/home/src/node_modules/app16/index.js":  `exports.name = "app16"`,
 	}
 
 	for i, tc := range []struct {
@@ -396,6 +397,8 @@ func TestResolve(t *testing.T) {
 		{"/", "./app13/app13", true, "name", "app13"},
 		{".", "app14", true, "name", "app14"},
 		{"..", "nonexistent", false, "", ""},
+		{"", "app16", true, "name", "app16"},                     // Fails
+		{"/home/src/packages/a", "app16", true, "name", "app16"}, // passes
 	} {
 		vm, mod, err := testRequire(tc.src, tc.path, globalFolders, fs)
 		if err != nil {

--- a/require/resolve.go
+++ b/require/resolve.go
@@ -3,6 +3,7 @@ package require
 import (
 	"encoding/json"
 	"errors"
+	"os"
 	"path"
 	"path/filepath"
 	"runtime"
@@ -197,10 +198,14 @@ func (r *RequireModule) loadNodeModules(modpath, start string) (module *js.Objec
 func (r *RequireModule) getCurrentModulePath() string {
 	var buf [2]js.StackFrame
 	frames := r.runtime.CaptureCallStack(2, buf[:0])
-	if len(frames) < 2 {
-		return "."
+	start := "."
+	if len(frames) >= 2 {
+		start = path.Dir(frames[1].SrcName())
 	}
-	return path.Dir(frames[1].SrcName())
+	if start == "." {
+		start, _ = os.Getwd()
+	}
+	return start
 }
 
 func (r *RequireModule) createModuleObject() *js.Object {

--- a/require/resolve.go
+++ b/require/resolve.go
@@ -3,7 +3,6 @@ package require
 import (
 	"encoding/json"
 	"errors"
-	"os"
 	"path"
 	"path/filepath"
 	"runtime"
@@ -198,14 +197,10 @@ func (r *RequireModule) loadNodeModules(modpath, start string) (module *js.Objec
 func (r *RequireModule) getCurrentModulePath() string {
 	var buf [2]js.StackFrame
 	frames := r.runtime.CaptureCallStack(2, buf[:0])
-	start := "."
-	if len(frames) >= 2 {
-		start = path.Dir(frames[1].SrcName())
+	if len(frames) < 2 {
+		return "."
 	}
-	if start == "." {
-		start, _ = os.Getwd()
-	}
-	return start
+	return path.Dir(frames[1].SrcName())
 }
 
 func (r *RequireModule) createModuleObject() *js.Object {


### PR DESCRIPTION
There are cases such as in PocketBase where `frames[1].SrcName()` is empty. 

An empty src name causes `getCurrentModulePath()` to return `.`, but that will not traverse up to parent directories to search for ancestor `node_modules` because [parent := path.Dir(start)](https://github.com/benallfree/goja_nodejs/blob/f931140e79b97c66c2ce9d59cbabe4e7cbed88ec/require/resolve.go#L192) fails (`path.Dir(".") == "."`).

This fix returns an absolute path instead of `.`, which allows `resolve()` to correctly traverse parents.

Tagging @ganigeorgiev for further discussion and input if needed.