### PR TITLE
Feat: add support for NODE_DEBUG=module

### DIFF
--- a/require/resolve.go
+++ b/require/resolve.go
@@ -64,6 +64,7 @@ func (r *RequireModule) resolve(modpath string) (module *js.Object, err error) {
 	}
 
 	if module == nil && err == nil {
+		moduleDebug(fmt.Sprintf("resolve %s (fatal)", modpath))
 		err = InvalidModuleError
 	}
 	return


### PR DESCRIPTION
This PR mimics [NODE_DEBUG=module](https://nodejs.org/docs/latest/api/all.html#all_cli_node_debugmodule) by outputting module resolution debugging information.

Example:

```bash
NODE_DEBUG=module air
```

Outputs...

```
resolve buffer (native)
resolve util (native)
resolve console (native)
resolve process (native)
resolve /my_project/node_modules/pocketpages/dist/node_modules/qs-lite (not found)
resolve /my_project/node_modules/pocketpages/dist/node_modules/qs-lite.js (not found)
resolve /my_project/node_modules/pocketpages/dist/node_modules/qs-lite.json (not found)
resolve /my_project/node_modules/pocketpages/dist/node_modules/qs-lite/index.js (not found)
resolve /my_project/node_modules/pocketpages/dist/node_modules/qs-lite/index.json (not found)
resolve /my_project/node_modules/pocketpages/node_modules/qs-lite (not found)
resolve /my_project/node_modules/pocketpages/node_modules/qs-lite.js (not found)
resolve /my_project/node_modules/pocketpages/node_modules/qs-lite.json (not found)
resolve /my_project/node_modules/pocketpages/node_modules/qs-lite/index.js (not found)
resolve /my_project/node_modules/pocketpages/node_modules/qs-lite/index.json (not found)
resolve /my_project/node_modules/qs-lite (not found)
resolve /my_project/node_modules/qs-lite.js (not found)
resolve /my_project/node_modules/qs-lite.json (not found)
resolve /my_project/node_modules/qs-lite/qs-lite.js (ok)
resolve /my_project/node_modules/pocketpages (not found)
resolve /my_project/node_modules/pocketpages.js (not found)
resolve /my_project/node_modules/pocketpages.json (not found)
resolve /my_project/node_modules/pocketpages/index.js (not found)
resolve /my_project/node_modules/pocketpages/index.json (not found)
resolve pocketpages (fatal)
Failed to execute pocketpages.pb.js:
 - GoError: Invalid module at github.com/dop251/goja_nodejs/require.(*RequireModule).require-fm (native)
```

